### PR TITLE
feat!: refactor ksvc to support multiple Knative services

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -111,3 +111,38 @@ jobs:
           helm template test-release examples/${{ matrix.example }} \
             --namespace test-ns | \
             kubectl apply --dry-run=server -f - 2>&1 || true
+
+  app-chart:
+    name: App Chart Dry-Run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.17.0
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: test-cluster
+
+      - name: Install Knative Serving CRDs
+        run: |
+          kubectl apply --server-side -f https://github.com/knative/serving/releases/download/knative-v1.17.0/serving-crds.yaml
+          kubectl wait --for=condition=Established crd/services.serving.knative.dev --timeout=60s
+
+      - name: Resolve app chart dependency locally
+        run: |
+          sed -i 's|repository: oci://ghcr.io/enchantednatures/charts|repository: "file://../../library/ksvc"|' charts/app/ksvc/Chart.yaml
+          helm dependency update charts/app/ksvc
+
+      - name: Helm dry-run install app chart
+        run: |
+          helm install test-app charts/app/ksvc \
+            --namespace test-ns \
+            --create-namespace \
+            --set services.api.image.repository=ghcr.io/test/app \
+            --set services.api.image.tag=v1.0.0 \
+            --dry-run=server \
+            --timeout 120s

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -23,6 +23,13 @@ jobs:
       - name: Lint library chart
         run: helm lint charts/library/ksvc
 
+      - name: Lint app chart
+        run: |
+          sed -i 's|repository: oci://ghcr.io/enchantednatures/charts|repository: "file://../../library/ksvc"|' charts/app/ksvc/Chart.yaml
+          helm dependency update charts/app/ksvc
+          helm lint charts/app/ksvc
+          git checkout charts/app/ksvc/Chart.yaml
+
       - name: Lint all examples
         run: |
           for example in examples/*/; do
@@ -83,6 +90,19 @@ jobs:
 
       - name: Install yamllint
         run: pip install yamllint
+
+      - name: Render and validate app chart
+        run: |
+          sed -i 's|repository: oci://ghcr.io/enchantednatures/charts|repository: "file://../../library/ksvc"|' charts/app/ksvc/Chart.yaml
+          helm dependency update charts/app/ksvc
+          helm template test-app charts/app/ksvc \
+            --namespace test-ns \
+            --set services.api.image.repository=ghcr.io/test/app \
+            --set services.api.image.tag=v1.0.0 > /tmp/rendered-app.yaml
+          yamllint -d relaxed /tmp/rendered-app.yaml
+          echo "Resources rendered for app chart:"
+          grep -E "^kind:" /tmp/rendered-app.yaml | sort | uniq -c
+          git checkout charts/app/ksvc/Chart.yaml
 
       - name: Render and validate all examples
         run: |

--- a/charts/app/ksvc/Chart.yaml
+++ b/charts/app/ksvc/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: ksvc-app
+description: >-
+  A ksvc library powered chart template for deploying Knative Services with
+  optional CloudNativePG PostgreSQL, Kafka event sources, DragonflyDB cache
+  clusters, and Flagger canary releases.
+type: application
+version: 0.2.0
+appVersion: "1.0.0"
+kubeVersion: ">=1.28.0"
+home: https://github.com/enchantednatures/charts
+sources:
+  - https://github.com/enchantednatures/charts
+maintainers:
+  - name: enchantednatures
+    url: https://github.com/enchantednatures
+keywords:
+  - knative
+  - serverless
+  - cloudnativepg
+  - dragonfly
+  - flagger
+  - kafka
+dependencies:
+  - name: ksvc
+    version: 0.2.0
+    repository: oci://ghcr.io/enchantednatures/charts
+annotations:
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/license: MIT

--- a/charts/app/ksvc/templates/common.yaml
+++ b/charts/app/ksvc/templates/common.yaml
@@ -1,0 +1,1 @@
+{{- include "ksvc.loader.generate" . }}

--- a/charts/app/ksvc/values.yaml
+++ b/charts/app/ksvc/values.yaml
@@ -1,0 +1,8 @@
+## This chart wraps the ksvc library chart so it can be installed directly.
+## All values are passed through to the library — see the library chart's
+## values.yaml for the full reference.
+##
+## Quick start:
+##   helm install my-svc oci://ghcr.io/enchantednatures/charts/ksvc-app \
+##     --set services.api.image.repository=ghcr.io/my-org/my-app \
+##     --set services.api.image.tag=v1.0.0

--- a/charts/library/ksvc/README.md
+++ b/charts/library/ksvc/README.md
@@ -1,23 +1,45 @@
 # ksvc
 
-Helm library chart for Knative services with integrated CloudNativePG, Kafka, and Flagger.
+Helm library chart for deploying **multiple Knative services** with integrated CloudNativePG, Kafka event sources, DragonflyDB, and Flagger canary releases.
 
 ## Overview
 
-This library chart provides a standardized way to deploy serverless applications on Kubernetes using Knative. It replaces repetitive boilerplate by rendering a Knative Service alongside optional dependencies like PostgreSQL clusters, Kafka event sources, and canary release configurations.
+This library chart provides a standardized way to deploy serverless applications on Kubernetes using Knative Serving. Consumers define one or more services via a `services:` map, and the library renders all required Kubernetes and Custom Resource manifests.
+
+Infrastructure resources (PostgreSQL, DragonflyDB) are shared globally across all services in the release, while Kafka event sources and Flagger canary configs are scoped per-source and per-service respectively.
 
 ## Architecture
 
-The chart follows a library pattern to ensure consistency across multiple services:
+```
+Consumer Chart
+  └── templates/common.yaml
+        └── {{ include "ksvc.loader.generate" . }}
+              ├── Validators (sink refs, required fields)
+              ├── Per-service loop (services map)
+              │     ├── Knative Service
+              │     └── Flagger Canary (opt-in)
+              ├── Per-source loop (kafka.sources map)
+              │     ├── KafkaSource
+              │     └── DLQ Knative Service (opt-in)
+              └── Global resources
+                    ├── CNPG Cluster, Pooler, Backup, ObjectStore, PodMonitor, Alerts
+                    └── Dragonfly
+```
 
-1.  **Loader**: The consumer chart calls `ksvc.loader.generate` from its templates.
-2.  **Defaults**: The library applies opinionated defaults using `mustMergeOverwrite` to compensate for Helm's lack of library value merging.
-3.  **Classes**: Dedicated template classes manage specific resource groups (Knative, CNPG, Kafka, Flagger).
-4.  **Resources**: Standard Kubernetes and Custom Resource manifests are rendered based on the enabled features.
+### Naming Conventions
+
+| Resource | Name Pattern |
+|----------|-------------|
+| Knative Service | `<release>-<service-key>` |
+| Flagger Canary | `<release>-<service-key>` |
+| KafkaSource | `<release>-<source-key>-kafka-source` |
+| DLQ Service | `<release>-<source-key>-dlq` |
+| CNPG Cluster | `<release>` (global) |
+| Dragonfly | `<release>` (global) |
 
 ## Quick Start
 
-1.  Create a new Helm chart to consume the library:
+1.  Create a new Helm chart:
     ```bash
     helm create my-service
     rm -rf my-service/templates/*
@@ -27,7 +49,7 @@ The chart follows a library pattern to ensure consistency across multiple servic
     ```yaml
     dependencies:
       - name: ksvc
-        version: 0.1.0
+        version: 0.2.0
         repository: oci://ghcr.io/enchantednatures/charts
     ```
 
@@ -38,58 +60,110 @@ The chart follows a library pattern to ensure consistency across multiple servic
 
 4.  Configure `values.yaml`:
     ```yaml
-    knativeService:
-      image:
-        repository: ghcr.io/my-org/my-service
-        tag: v1.0.0
+    services:
+      api:
+        image:
+          repository: ghcr.io/my-org/my-api
+          tag: v1.0.0
+      worker:
+        image:
+          repository: ghcr.io/my-org/my-worker
+          tag: v1.0.0
     ```
+
+    This renders two Knative Services: `my-service-api` and `my-service-worker`.
 
 ## Resources Rendered
 
-| Feature | Resources Rendered |
-|---------|-------------------|
-| **Base** | Knative Service |
-| **PostgreSQL** | Cluster, Pooler, ObjectStore, ScheduledBackup, PodMonitor, PrometheusRule |
-| **Kafka** | KafkaSource, Knative Service (DLQ) |
-| **DragonflyDB** | Dragonfly |
-| **Flagger** | Canary |
+| Feature | Resources Rendered | Scope |
+|---------|-------------------|-------|
+| **Services** | Knative Service (per entry in `services`) | Per-service |
+| **Flagger** | Canary (per service with `flagger.enabled: true`) | Per-service |
+| **Kafka** | KafkaSource (per entry in `kafka.sources`) | Per-source |
+| **Kafka DLQ** | Knative Service (per source with `dlq.enabled: true`) | Per-source |
+| **PostgreSQL** | Cluster, Pooler, ObjectStore, ScheduledBackup, PodMonitor, PrometheusRule | Global |
+| **DragonflyDB** | Dragonfly | Global |
 
 ## Values Reference
 
 ### Global Settings
+
 | Key | Description | Default |
 |-----|-------------|---------|
 | `global.nameOverride` | Override chart name | `""` |
 | `global.fullnameOverride` | Override fullname | `""` |
-| `global.labels` | Labels for all resources | `{}` |
-| `global.annotations` | Annotations for all resources | `{}` |
+| `global.labels` | Labels applied to all resources | `{}` |
+| `global.annotations` | Annotations applied to all resources | `{}` |
 
-### Knative Service
+### Services (Map)
+
+Each key in `services:` defines a Knative Service. The key becomes a name suffix: `<release>-<key>`.
+
 | Key | Description | Default |
 |-----|-------------|---------|
-| `knativeService.image.repository` | Container image repository | `""` |
-| `knativeService.image.tag` | Container image tag | `"latest"` |
-| `knativeService.image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `knativeService.image.fluxImagePolicy` | Flux image policy annotation | `""` |
-| `knativeService.scaling.minScale` | Minimum replicas | `1` |
-| `knativeService.scaling.maxScale` | Maximum replicas | `10` |
-| `knativeService.scaling.target` | Scaling target | `100` |
-| `knativeService.scaling.containerConcurrency` | Max requests per pod | `100` |
-| `knativeService.scaling.timeoutSeconds` | Request timeout | `300` |
-| `knativeService.scaling.class` | Autoscaler class | `""` |
-| `knativeService.resources` | Container CPU/Memory resources | See values.yaml |
-| `knativeService.port` | Container port | `8080` |
-| `knativeService.probes` | Liveness and Readiness probes | See values.yaml |
-| `knativeService.env` | List of environment variables | `[]` |
-| `knativeService.envFrom` | envFrom sources (Secrets/ConfigMaps) | `[]` |
-| `knativeService.securityContext` | Pod security settings | See values.yaml |
-| `knativeService.volumeMounts` | Container volume mounts | `[]` |
-| `knativeService.volumes` | Pod volumes | `[]` |
-| `knativeService.podAnnotations` | Annotations for the Pod | Prometheus scraping enabled |
-| `knativeService.annotations` | Annotations for the Service | Prometheus scraping enabled |
-| `knativeService.labels` | Labels for the Service | `{}` |
+| `services.<key>.image.repository` | Container image repository | `""` |
+| `services.<key>.image.tag` | Container image tag | `"latest"` |
+| `services.<key>.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `services.<key>.image.fluxImagePolicy` | Flux image policy annotation | `""` |
+| `services.<key>.scaling.minScale` | Minimum replicas | `1` |
+| `services.<key>.scaling.maxScale` | Maximum replicas | `10` |
+| `services.<key>.scaling.target` | Scaling target | `100` |
+| `services.<key>.scaling.containerConcurrency` | Max concurrent requests per pod | `100` |
+| `services.<key>.scaling.timeoutSeconds` | Request timeout | `300` |
+| `services.<key>.scaling.class` | Autoscaler class | `""` |
+| `services.<key>.resources` | Container CPU/Memory resources | 100m/64Mi req, 500m/256Mi lim |
+| `services.<key>.port` | Container port | `8080` |
+| `services.<key>.probes.liveness` | Liveness probe config | See values.yaml |
+| `services.<key>.probes.readiness` | Readiness probe config | See values.yaml |
+| `services.<key>.env` | Environment variables | `[]` |
+| `services.<key>.envFrom` | envFrom sources (Secrets/ConfigMaps) | `[]` |
+| `services.<key>.securityContext` | Container security context | runAsNonRoot, readOnly, drop ALL |
+| `services.<key>.volumeMounts` | Container volume mounts | `[]` |
+| `services.<key>.volumes` | Pod volumes | `[]` |
+| `services.<key>.podAnnotations` | Annotations for the Pod template | Prometheus scraping enabled |
+| `services.<key>.annotations` | Annotations for the Knative Service | Prometheus scraping enabled |
+| `services.<key>.labels` | Additional labels for the Knative Service | `{}` |
+
+### Flagger Canary (Per-Service)
+
+Flagger is configured inside each service entry.
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `services.<key>.flagger.enabled` | Enable Flagger canary for this service | `false` |
+| `services.<key>.flagger.analysis.interval` | Analysis check interval | `"1m"` |
+| `services.<key>.flagger.analysis.threshold` | Failure threshold before rollback | `5` |
+| `services.<key>.flagger.analysis.maxWeight` | Maximum traffic weight (%) | `50` |
+| `services.<key>.flagger.analysis.stepWeight` | Traffic increment step (%) | `10` |
+| `services.<key>.flagger.analysis.progressDeadlineSeconds` | Max seconds for canary progress | `120` |
+| `services.<key>.flagger.metrics.successRateThreshold` | Min success rate (%) | `99` |
+| `services.<key>.flagger.metrics.latencyP99ThresholdMs` | Max p99 latency (ms) | `500` |
+| `services.<key>.flagger.metrics.prometheusAddress` | Prometheus server address | `http://prometheus.observability...` |
+| `services.<key>.flagger.loadTest.enabled` | Enable k6 load testing | `true` |
+| `services.<key>.flagger.loadTest.webhookUrl` | k6 loadtester webhook URL | `http://k6-loadtester.flagger-system/...` |
+| `services.<key>.flagger.loadTest.vus` | Virtual users | `10` |
+| `services.<key>.flagger.loadTest.duration` | Test duration | `"1m"` |
+
+### Kafka Event Sources (Map)
+
+Each key in `kafka.sources:` defines a KafkaSource. The `sink` field must reference a valid key in the `services` map (validated at render time).
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `kafka.sources.<key>.topic` | Kafka topic name | `"events"` |
+| `kafka.sources.<key>.sink` | **Required.** Key from the `services` map | — |
+| `kafka.sources.<key>.consumerGroup` | Consumer group (defaults to source name) | `""` |
+| `kafka.sources.<key>.bootstrapServers` | List of bootstrap servers | `[kafka.kafka.svc:9092]` |
+| `kafka.sources.<key>.consumers` | Concurrent consumers per replica | `3` |
+| `kafka.sources.<key>.initialOffset` | `latest` or `earliest` | `latest` |
+| `kafka.sources.<key>.delivery.retry` | Delivery retry count | `5` |
+| `kafka.sources.<key>.delivery.backoffPolicy` | `linear` or `exponential` | `exponential` |
+| `kafka.sources.<key>.delivery.backoffDelay` | Backoff delay (ISO 8601) | `PT1S` |
+| `kafka.sources.<key>.dlq.enabled` | Enable Dead Letter Queue service | `true` |
+| `kafka.sources.<key>.dlq.image` | DLQ container image | `event_display` |
 
 ### CloudNativePG PostgreSQL
+
 | Key | Description | Default |
 |-----|-------------|---------|
 | `postgres.enabled` | Enable PostgreSQL cluster | `false` |
@@ -112,34 +186,8 @@ The chart follows a library pattern to ensure consistency across multiple servic
 | `postgres.monitoring.enabled` | Enable PodMonitor and Alerts | `true` |
 | `postgres.monitoring.alerts` | Thresholds for Prometheus rules | See values.yaml |
 
-### Kafka Event Source
-| Key | Description | Default |
-|-----|-------------|---------|
-| `kafka.enabled` | Enable Kafka source | `false` |
-| `kafka.source.topic` | Kafka topic name | `"events"` |
-| `kafka.source.consumerGroup` | Kafka consumer group | `""` |
-| `kafka.source.bootstrapServers` | List of bootstrap servers | `[kafka.kafka.svc:9092]` |
-| `kafka.source.consumers` | Concurrent consumers per replica | `3` |
-| `kafka.source.initialOffset` | latest/earliest | `latest` |
-| `kafka.delivery.retry` | Delivery retry count | `5` |
-| `kafka.delivery.backoffPolicy` | linear/exponential | `exponential` |
-| `kafka.delivery.backoffDelay` | Backoff delay (ISO8601) | `PT1S` |
-| `kafka.dlq.enabled` | Enable Dead Letter Queue | `true` |
-| `kafka.dlq.image` | DLQ event display image | `event_display` |
-
-### Flagger Canary Release
-| Key | Description | Default |
-|-----|-------------|---------|
-| `flagger.enabled` | Enable Flagger canary | `false` |
-| `flagger.analysis.interval` | Check interval | `"1m"` |
-| `flagger.analysis.threshold` | Failure threshold | `5` |
-| `flagger.analysis.maxWeight` | Maximum traffic weight | `50` |
-| `flagger.analysis.stepWeight` | Traffic increment step | `10` |
-| `flagger.metrics` | Success/Latency thresholds | 99% success, 500ms p99 |
-| `flagger.loadTest.enabled` | Enable k6 load testing | `true` |
-| `flagger.loadTest.webhookUrl` | k6 loadtester service URL | `""` |
-
 ### DragonflyDB Cache Cluster
+
 | Key | Description | Default |
 |-----|-------------|---------|
 | `dragonfly.enabled` | Enable DragonflyDB cluster | `false` |
@@ -170,15 +218,77 @@ The chart follows a library pattern to ensure consistency across multiple servic
 | `dragonfly.serviceAccountName` | Service account name | `""` |
 | `dragonfly.priorityClassName` | Priority class name | `""` |
 
+## Migration from v0.1.x
+
+v0.2.0 is a **breaking change**. The `knativeService:` and top-level `flagger:` / `kafka:` keys have been replaced.
+
+### Key changes
+
+| v0.1.x | v0.2.0 |
+|--------|--------|
+| `knativeService.image.repository` | `services.<key>.image.repository` |
+| `knativeService.scaling.*` | `services.<key>.scaling.*` |
+| `flagger.enabled` | `services.<key>.flagger.enabled` |
+| `kafka.enabled` | Remove — presence of `kafka.sources` entries enables Kafka |
+| `kafka.source.topic` | `kafka.sources.<key>.topic` |
+| `kafka.source.sink` (implicit) | `kafka.sources.<key>.sink` (explicit, validated) |
+
+### Migration steps
+
+1. Replace `knativeService:` with a named entry under `services:`:
+   ```yaml
+   # Before (v0.1.x)
+   knativeService:
+     image:
+       repository: ghcr.io/org/my-app
+       tag: v1.0.0
+
+   # After (v0.2.0)
+   services:
+     app:
+       image:
+         repository: ghcr.io/org/my-app
+         tag: v1.0.0
+   ```
+
+2. Move `flagger:` inside the service entry:
+   ```yaml
+   # Before
+   flagger:
+     enabled: true
+
+   # After
+   services:
+     app:
+       flagger:
+         enabled: true
+   ```
+
+3. Convert `kafka:` to `kafka.sources:` map with explicit `sink`:
+   ```yaml
+   # Before
+   kafka:
+     enabled: true
+     source:
+       topic: my-events
+
+   # After
+   kafka:
+     sources:
+       events:
+         topic: my-events
+         sink: app    # must match a key in services
+   ```
+
 ## Examples
 
-The [examples/](../../../examples/) directory contains several reference implementations:
+The [examples/](../../../examples/) directory contains reference implementations:
 
-*   **minimal**: A basic Knative service with environment variables and resource limits.
-*   **full-stack**: A complete deployment including PostgreSQL (with backups), Kafka event source (with DLQ), DragonflyDB cache, and Flagger canary analysis.
-*   **postgres-only**: Focuses on the CloudNativePG integration for API services requiring state.
-*   **kafka-consumer**: Demonstrates scaling a consumer service based on Kafka topic throughput.
-*   **dragonfly-cache**: Demonstrates a Knative service with DragonflyDB for caching, including auth, TLS, and PVC snapshots.
+*   **minimal** — Single Knative service with env vars and resource limits.
+*   **full-stack** — Multi-service deployment with PostgreSQL, Kafka, DragonflyDB, and Flagger.
+*   **postgres-only** — API service with CloudNativePG integration.
+*   **kafka-consumer** — Consumer service with KafkaSource and DLQ.
+*   **dragonfly-cache** — Knative service with DragonflyDB caching, auth, TLS, and snapshots.
 
 ## CI/CD
 
@@ -190,9 +300,7 @@ The repository uses GitHub Actions for automated quality assurance:
 
 ## Testing
 
-Unit tests are written using the `helm-unittest` plugin and located in the `test-chart` wrapper.
-
-To run tests locally:
+Unit tests use the `helm-unittest` plugin and live in the `test-chart` wrapper.
 
 ```bash
 cd charts/library/ksvc

--- a/charts/library/ksvc/templates/classes/_flagger-canary.tpl
+++ b/charts/library/ksvc/templates/classes/_flagger-canary.tpl
@@ -1,20 +1,25 @@
+{{/*
+ksvc.class.flaggerCanary — Render a Flagger Canary for a specific service.
+Expects context: dict with "root" (top-level context), "key" (service map key),
+and "svc" (the merged service config dict containing flagger sub-config).
+*/}}
 {{- define "ksvc.class.flaggerCanary" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
-{{- $flagger := .Values.flagger -}}
+{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key) -}}
+{{- $flagger := .svc.flagger -}}
 {{- $lt := $flagger.loadTest -}}
 apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
-  name: {{ $fullname }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ $serviceName }}
+  namespace: {{ .root.Release.Namespace }}
   labels:
-    {{- include "ksvc.labels" . | nindent 4 }}
+    {{- include "ksvc.serviceLabels" (dict "root" .root "key" .key "svc" .svc) | nindent 4 }}
 spec:
   provider: knative
   targetRef:
     apiVersion: serving.knative.dev/v1
     kind: Service
-    name: {{ $fullname }}
+    name: {{ $serviceName }}
   progressDeadlineSeconds: {{ $flagger.analysis.progressDeadlineSeconds }}
   analysis:
     interval: {{ $flagger.analysis.interval }}
@@ -57,7 +62,7 @@ spec:
 
             export default function () {
               const res = http.get(
-                'http://{{ $fullname }}-canary.{{ .Release.Namespace }}.svc.cluster.local/health/live'
+                'http://{{ $serviceName }}-canary.{{ .root.Release.Namespace }}.svc.cluster.local/health/live'
               );
               check(res, {
                 'smoke: status is 200': (r) => r.status === 200,
@@ -92,7 +97,7 @@ spec:
 
             export default function () {
               const res = http.get(
-                'http://{{ $fullname }}-canary.{{ .Release.Namespace }}.svc.cluster.local/'
+                'http://{{ $serviceName }}-canary.{{ .root.Release.Namespace }}.svc.cluster.local/'
               );
               const ok = check(res, {
                 'status is 2xx': (r) => r.status >= 200 && r.status < 300,

--- a/charts/library/ksvc/templates/classes/_kafka-dlq.tpl
+++ b/charts/library/ksvc/templates/classes/_kafka-dlq.tpl
@@ -1,13 +1,19 @@
+{{/*
+ksvc.class.kafkaDlq — Render a DLQ Knative Service for a specific kafka source.
+Expects context: dict with "root" (top-level context), "key" (source map key),
+and "source" (the merged kafka source config dict containing dlq sub-config).
+*/}}
 {{- define "ksvc.class.kafkaDlq" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
-{{- $dlq := .Values.kafka.dlq -}}
+{{- $fullname := include "ksvc.fullname" .root -}}
+{{- $dlq := .source.dlq -}}
+{{- $dlqName := printf "%s-%s-dlq" $fullname .key | trunc 63 | trimSuffix "-" -}}
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: {{ $fullname }}-dlq
-  namespace: {{ .Release.Namespace }}
+  name: {{ $dlqName }}
+  namespace: {{ .root.Release.Namespace }}
   labels:
-    {{- include "ksvc.labels" . | nindent 4 }}
+    {{- include "ksvc.labels" .root | nindent 4 }}
     app.kubernetes.io/component: dlq-handler
 spec:
   template:

--- a/charts/library/ksvc/templates/classes/_kafka-source.tpl
+++ b/charts/library/ksvc/templates/classes/_kafka-source.tpl
@@ -1,36 +1,45 @@
+{{/*
+ksvc.class.kafkaSource — Render a KafkaSource for a specific source entry.
+Expects context: dict with "root" (top-level context), "key" (source map key),
+and "source" (the merged kafka source config dict).
+The source.sink field must reference a valid key in .Values.services.
+*/}}
 {{- define "ksvc.class.kafkaSource" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
-{{- $kafka := .Values.kafka -}}
+{{- $fullname := include "ksvc.fullname" .root -}}
+{{- $source := .source -}}
+{{- $sinkServiceName := include "ksvc.serviceName" (dict "root" .root "key" $source.sink) -}}
+{{- $sourceName := printf "%s-%s-kafka-source" $fullname .key | trunc 63 | trimSuffix "-" -}}
+{{- $dlqName := printf "%s-%s-dlq" $fullname .key | trunc 63 | trimSuffix "-" -}}
 apiVersion: sources.knative.dev/v1beta1
 kind: KafkaSource
 metadata:
-  name: {{ $fullname }}-kafka-source
-  namespace: {{ .Release.Namespace }}
+  name: {{ $sourceName }}
+  namespace: {{ .root.Release.Namespace }}
   labels:
-    {{- include "ksvc.labels" . | nindent 4 }}
+    {{- include "ksvc.labels" .root | nindent 4 }}
     app.kubernetes.io/component: event-source
 spec:
-  consumerGroup: {{ default (printf "%s-consumers" $fullname) $kafka.source.consumerGroup }}
-  consumers: {{ $kafka.source.consumers }}
+  consumerGroup: {{ default (printf "%s-%s-consumers" $fullname .key) $source.consumerGroup }}
+  consumers: {{ $source.consumers }}
   bootstrapServers:
-    {{- toYaml $kafka.source.bootstrapServers | nindent 4 }}
+    {{- toYaml $source.bootstrapServers | nindent 4 }}
   topics:
-    - {{ $kafka.source.topic }}
+    - {{ $source.topic }}
   sink:
     ref:
       apiVersion: serving.knative.dev/v1
       kind: Service
-      name: {{ $fullname }}
+      name: {{ $sinkServiceName }}
   delivery:
-    retry: {{ $kafka.delivery.retry }}
-    backoffPolicy: {{ $kafka.delivery.backoffPolicy }}
-    backoffDelay: {{ $kafka.delivery.backoffDelay }}
-    {{- if $kafka.dlq.enabled }}
+    retry: {{ $source.delivery.retry }}
+    backoffPolicy: {{ $source.delivery.backoffPolicy }}
+    backoffDelay: {{ $source.delivery.backoffDelay }}
+    {{- if and $source.dlq $source.dlq.enabled }}
     deadLetterSink:
       ref:
         apiVersion: serving.knative.dev/v1
         kind: Service
-        name: {{ $fullname }}-dlq
+        name: {{ $dlqName }}
     {{- end }}
-  initialOffset: {{ $kafka.source.initialOffset }}
+  initialOffset: {{ $source.initialOffset }}
 {{- end }}

--- a/charts/library/ksvc/templates/classes/_knative-service.tpl
+++ b/charts/library/ksvc/templates/classes/_knative-service.tpl
@@ -1,18 +1,19 @@
+{{/*
+ksvc.class.knativeService — Render a Knative Service.
+Expects context: dict with "root" (top-level context), "key" (service map key),
+and "svc" (the merged service config dict).
+*/}}
 {{- define "ksvc.class.knativeService" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
-{{- $svc := .Values.knativeService -}}
+{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key) -}}
+{{- $svc := .svc -}}
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: {{ $fullname }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ $serviceName }}
+  namespace: {{ .root.Release.Namespace }}
   labels:
-    {{- include "ksvc.labels" . | nindent 4 }}
-    app.kubernetes.io/component: api
-    {{- with $svc.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- $globalAnnotations := include "ksvc.annotations" . -}}
+    {{- include "ksvc.serviceLabels" (dict "root" .root "key" .key "svc" $svc) | nindent 4 }}
+  {{- $globalAnnotations := include "ksvc.annotations" .root -}}
   {{- if or $globalAnnotations $svc.annotations }}
   annotations:
     {{- with $globalAnnotations }}

--- a/charts/library/ksvc/templates/lib/_labels.tpl
+++ b/charts/library/ksvc/templates/lib/_labels.tpl
@@ -19,3 +19,24 @@ Selector labels (subset for matchLabels).
 app.kubernetes.io/name: {{ include "ksvc.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+ksvc.serviceLabels — Labels for a specific service entry.
+Expects context: dict with "root" (top-level context), "key" (service map key),
+and "svc" (the service config dict).
+*/}}
+{{- define "ksvc.serviceLabels" -}}
+{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key) -}}
+app.kubernetes.io/name: {{ $serviceName }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+helm.sh/chart: {{ include "ksvc.chart" .root }}
+app.kubernetes.io/component: {{ .key }}
+{{- if and .root.Values.global .root.Values.global.labels }}
+{{ toYaml .root.Values.global.labels }}
+{{- end }}
+{{- with .svc.labels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/library/ksvc/templates/lib/_names.tpl
+++ b/charts/library/ksvc/templates/lib/_names.tpl
@@ -27,3 +27,13 @@ Chart label value.
 {{- define "ksvc.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+ksvc.serviceName — Derive resource name for a service entry.
+Expects context: dict with "root" (top-level context) and "key" (service map key).
+Returns: <fullname>-<key>
+*/}}
+{{- define "ksvc.serviceName" -}}
+{{- $fullname := include "ksvc.fullname" .root -}}
+{{- printf "%s-%s" $fullname .key | trunc 63 | trimSuffix "-" | replace "_" "-" }}
+{{- end }}

--- a/charts/library/ksvc/templates/lib/_validators.tpl
+++ b/charts/library/ksvc/templates/lib/_validators.tpl
@@ -3,13 +3,44 @@ Validate required values at template render time.
 Call this from the loader to catch misconfigurations early.
 */}}
 {{- define "ksvc.validate" -}}
-  {{- if not .Values.knativeService.image.repository -}}
-    {{- fail "knativeService.image.repository is required" -}}
+  {{/* services map must exist and have at least one entry */}}
+  {{- if not .Values.services -}}
+    {{- fail "services is required and must contain at least one service entry" -}}
   {{- end -}}
+  {{- if not (kindIs "map" .Values.services) -}}
+    {{- fail "services must be a map (e.g. services: { api: { ... } })" -}}
+  {{- end -}}
+  {{- if eq (len .Values.services) 0 -}}
+    {{- fail "services must contain at least one service entry" -}}
+  {{- end -}}
+
+  {{/* each service must have image.repository */}}
+  {{- range $key, $svc := .Values.services -}}
+    {{- if not $svc.image -}}
+      {{- fail (printf "services.%s.image is required" $key) -}}
+    {{- end -}}
+    {{- if not $svc.image.repository -}}
+      {{- fail (printf "services.%s.image.repository is required" $key) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/* postgres backup validation */}}
   {{- if and .Values.postgres.enabled .Values.postgres.backup.enabled (not .Values.postgres.backup.objectStore.destinationPath) -}}
     {{- fail "postgres.backup.objectStore.destinationPath is required when postgres backup is enabled" -}}
   {{- end -}}
   {{- if and .Values.postgres.enabled .Values.postgres.backup.enabled (not .Values.postgres.backup.objectStore.endpointURL) -}}
     {{- fail "postgres.backup.objectStore.endpointURL is required when postgres backup is enabled" -}}
+  {{- end -}}
+
+  {{/* kafka source sink validation: each source's sink must reference a valid services key */}}
+  {{- if and .Values.kafka .Values.kafka.sources -}}
+    {{- range $key, $source := .Values.kafka.sources -}}
+      {{- if not $source.sink -}}
+        {{- fail (printf "kafka.sources.%s.sink is required and must reference a key in the services map" $key) -}}
+      {{- end -}}
+      {{- if not (hasKey $.Values.services $source.sink) -}}
+        {{- fail (printf "kafka.sources.%s.sink references '%s' which does not exist in the services map" $key $source.sink) -}}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
 {{- end }}

--- a/charts/library/ksvc/templates/loader/_generate.tpl
+++ b/charts/library/ksvc/templates/loader/_generate.tpl
@@ -16,9 +16,22 @@ merged. We must apply defaults explicitly before rendering.
   {{- include "ksvc.validate" . -}}
 
   {{/* ============================================================ */}}
-  {{/* Knative Service (always rendered)                            */}}
+  {{/* Knative Services (iterate the services map)                  */}}
   {{/* ============================================================ */}}
-  {{- include "ksvc.class.knativeService" . | nindent 0 }}
+  {{- $isFirst := true -}}
+  {{- range $key, $svc := .Values.services }}
+    {{- if $isFirst -}}
+      {{- $isFirst = false -}}
+    {{- else }}
+---
+    {{- end }}
+  {{- include "ksvc.class.knativeService" (dict "root" $ "key" $key "svc" $svc) | nindent 0 }}
+    {{/* Flagger Canary (per-service opt-in) */}}
+    {{- if and $svc.flagger $svc.flagger.enabled }}
+---
+  {{- include "ksvc.class.flaggerCanary" (dict "root" $ "key" $key "svc" $svc) | nindent 0 }}
+    {{- end }}
+  {{- end }}
 
   {{/* ============================================================ */}}
   {{/* CloudNativePG PostgreSQL                                     */}}
@@ -45,14 +58,16 @@ merged. We must apply defaults explicitly before rendering.
   {{- end }}
 
   {{/* ============================================================ */}}
-  {{/* Kafka Event Source                                           */}}
+  {{/* Kafka Event Sources (iterate the kafka.sources map)          */}}
   {{/* ============================================================ */}}
-  {{- if and .Values.kafka .Values.kafka.enabled }}
+  {{- if and .Values.kafka .Values.kafka.sources }}
+    {{- range $key, $source := .Values.kafka.sources }}
 ---
-  {{- include "ksvc.class.kafkaSource" . | nindent 0 }}
-    {{- if and .Values.kafka.dlq .Values.kafka.dlq.enabled }}
+  {{- include "ksvc.class.kafkaSource" (dict "root" $ "key" $key "source" $source) | nindent 0 }}
+      {{- if and $source.dlq $source.dlq.enabled }}
 ---
-  {{- include "ksvc.class.kafkaDlq" . | nindent 0 }}
+  {{- include "ksvc.class.kafkaDlq" (dict "root" $ "key" $key "source" $source) | nindent 0 }}
+      {{- end }}
     {{- end }}
   {{- end }}
 
@@ -64,14 +79,6 @@ merged. We must apply defaults explicitly before rendering.
   {{- include "ksvc.class.dragonfly" . | nindent 0 }}
   {{- end }}
 
-  {{/* ============================================================ */}}
-  {{/* Flagger Canary Release                                      */}}
-  {{/* ============================================================ */}}
-  {{- if and .Values.flagger .Values.flagger.enabled }}
----
-  {{- include "ksvc.class.flaggerCanary" . | nindent 0 }}
-  {{- end }}
-
 {{- end }}
 
 {{/*
@@ -80,7 +87,8 @@ This compensates for Helm not merging library chart values.yaml automatically.
 Uses mustMergeOverwrite: consumer values take precedence over defaults.
 */}}
 {{- define "ksvc.loader.applyDefaults" -}}
-  {{/* --- knativeService defaults --- */}}
+
+  {{/* --- service defaults (applied to each entry in the services map) --- */}}
   {{- $svcDefaults := dict
     "image" (dict "repository" "" "tag" "latest" "pullPolicy" "IfNotPresent" "fluxImagePolicy" "")
     "scaling" (dict "minScale" 1 "maxScale" 10 "target" 100 "containerConcurrency" 100 "timeoutSeconds" 300 "class" "")
@@ -106,8 +114,49 @@ Uses mustMergeOverwrite: consumer values take precedence over defaults.
     "annotations" (dict "prometheus.io/scrape" "true" "prometheus.io/port" "8080" "prometheus.io/path" "/metrics")
     "labels" (dict)
   -}}
-  {{- $svc := .Values.knativeService | default dict -}}
-  {{- $_ := set .Values "knativeService" (mustMergeOverwrite $svcDefaults $svc) -}}
+
+  {{- $flaggerDefaults := dict
+    "enabled" false
+    "analysis" (dict "interval" "1m" "threshold" 5 "maxWeight" 50 "stepWeight" 10 "progressDeadlineSeconds" 120)
+    "metrics" (dict "successRateThreshold" 99 "latencyP99ThresholdMs" 500 "prometheusAddress" "http://prometheus.observability.svc.cluster.local:9090")
+    "loadTest" (dict "enabled" true "webhookUrl" "http://k6-loadtester.flagger-system/launch-test" "vus" 10 "duration" "1m" "p95ThresholdMs" 500 "errorRateThreshold" 0.01 "script" "")
+  -}}
+
+  {{- $services := .Values.services | default dict -}}
+  {{- range $key, $svc := $services }}
+    {{- $merged := mustMergeOverwrite (deepCopy $svcDefaults) $svc -}}
+    {{/* Merge flagger defaults into the service's flagger config */}}
+    {{- $svcFlagger := $merged.flagger | default dict -}}
+    {{- $_ := set $merged "flagger" (mustMergeOverwrite (deepCopy $flaggerDefaults) $svcFlagger) -}}
+    {{- $_ := set $services $key $merged -}}
+  {{- end }}
+  {{- $_ := set .Values "services" $services -}}
+
+  {{/* --- kafka source defaults (applied to each entry in kafka.sources map) --- */}}
+  {{- $kafkaSourceDefaults := dict
+    "topic" "events"
+    "consumerGroup" ""
+    "bootstrapServers" (list "kafka.kafka.svc.cluster.local:9092")
+    "consumers" 3
+    "initialOffset" "latest"
+    "sink" ""
+    "delivery" (dict "retry" 5 "backoffPolicy" "exponential" "backoffDelay" "PT1S")
+    "dlq" (dict "enabled" true
+      "image" (dict "repository" "gcr.io/knative-releases/knative.dev/eventing/cmd/event_display" "tag" "latest")
+      "scaling" (dict "minScale" 0 "maxScale" 2)
+      "resources" (dict "requests" (dict "cpu" "50m" "memory" "32Mi") "limits" (dict "cpu" "200m" "memory" "128Mi"))
+    )
+  -}}
+
+  {{- $kafka := .Values.kafka | default dict -}}
+  {{- if or (not (hasKey $kafka "sources")) (not $kafka.sources) -}}
+    {{- $_ := set $kafka "sources" dict -}}
+  {{- end -}}
+  {{- range $key, $source := $kafka.sources }}
+    {{- $merged := mustMergeOverwrite (deepCopy $kafkaSourceDefaults) $source -}}
+    {{- $_ := set $kafka.sources $key $merged -}}
+  {{- end }}
+  {{- $_ := set .Values "kafka" $kafka -}}
 
   {{/* --- postgres defaults --- */}}
   {{- $pgDefaults := dict
@@ -134,30 +183,6 @@ Uses mustMergeOverwrite: consumer values take precedence over defaults.
   -}}
   {{- $pg := .Values.postgres | default dict -}}
   {{- $_ := set .Values "postgres" (mustMergeOverwrite $pgDefaults $pg) -}}
-
-  {{/* --- kafka defaults --- */}}
-  {{- $kafkaDefaults := dict
-    "enabled" false
-    "source" (dict "topic" "events" "consumerGroup" "" "bootstrapServers" (list "kafka.kafka.svc.cluster.local:9092") "consumers" 3 "initialOffset" "latest")
-    "delivery" (dict "retry" 5 "backoffPolicy" "exponential" "backoffDelay" "PT1S")
-    "dlq" (dict "enabled" true
-      "image" (dict "repository" "gcr.io/knative-releases/knative.dev/eventing/cmd/event_display" "tag" "latest")
-      "scaling" (dict "minScale" 0 "maxScale" 2)
-      "resources" (dict "requests" (dict "cpu" "50m" "memory" "32Mi") "limits" (dict "cpu" "200m" "memory" "128Mi"))
-    )
-  -}}
-  {{- $kafka := .Values.kafka | default dict -}}
-  {{- $_ := set .Values "kafka" (mustMergeOverwrite $kafkaDefaults $kafka) -}}
-
-  {{/* --- flagger defaults --- */}}
-  {{- $flaggerDefaults := dict
-    "enabled" false
-    "analysis" (dict "interval" "1m" "threshold" 5 "maxWeight" 50 "stepWeight" 10 "progressDeadlineSeconds" 120)
-    "metrics" (dict "successRateThreshold" 99 "latencyP99ThresholdMs" 500 "prometheusAddress" "http://prometheus.observability.svc.cluster.local:9090")
-    "loadTest" (dict "enabled" true "webhookUrl" "http://k6-loadtester.flagger-system/launch-test" "vus" 10 "duration" "1m" "p95ThresholdMs" 500 "errorRateThreshold" 0.01 "script" "")
-  -}}
-  {{- $flagger := .Values.flagger | default dict -}}
-  {{- $_ := set .Values "flagger" (mustMergeOverwrite $flaggerDefaults $flagger) -}}
 
   {{/* --- dragonfly defaults --- */}}
   {{- $dfDefaults := dict

--- a/charts/library/ksvc/test-chart/tests/cnpg-cluster_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/cnpg-cluster_test.yaml
@@ -2,7 +2,7 @@ suite: cnpg cluster tests
 templates:
   - templates/common.yaml
 set:
-  knativeService.image.repository: test/image
+  services.api.image.repository: test/image
   postgres.enabled: true
   postgres.pooler.enabled: false
   postgres.backup.enabled: false

--- a/charts/library/ksvc/test-chart/tests/cnpg-pooler_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/cnpg-pooler_test.yaml
@@ -2,7 +2,7 @@ suite: cnpg pooler tests
 templates:
   - templates/common.yaml
 set:
-  knativeService.image.repository: test/image
+  services.api.image.repository: test/image
   postgres.enabled: true
   postgres.pooler.enabled: true
   postgres.backup.enabled: false
@@ -12,7 +12,7 @@ release:
   namespace: test-ns
 tests:
   # With postgres enabled + pooler enabled (no backup, no monitoring):
-  # doc 0 = Knative Service, doc 1 = CNPG Cluster, doc 2 = Pooler
+  # doc 0 = Knative Service (api), doc 1 = CNPG Cluster, doc 2 = Pooler
   - it: should render Pooler when enabled
     documentIndex: 2
     asserts:

--- a/charts/library/ksvc/test-chart/tests/dragonfly_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/dragonfly_test.yaml
@@ -2,7 +2,7 @@ suite: dragonfly tests
 templates:
   - templates/common.yaml
 set:
-  knativeService.image.repository: test/image
+  services.api.image.repository: test/image
   dragonfly.enabled: true
 release:
   name: test-release

--- a/charts/library/ksvc/test-chart/tests/flagger-canary_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/flagger-canary_test.yaml
@@ -2,14 +2,14 @@ suite: flagger canary tests
 templates:
   - templates/common.yaml
 set:
-  knativeService.image.repository: test/image
-  flagger.enabled: true
+  services.api.image.repository: test/image
+  services.api.flagger.enabled: true
 release:
   name: test-release
   namespace: test-ns
 tests:
-  # With flagger enabled:
-  # doc 0 = Knative Service, doc 1 = Canary
+  # With flagger enabled on 'api' service:
+  # doc 0 = Knative Service (api), doc 1 = Canary (api)
   - it: should render Canary when flagger enabled
     documentIndex: 1
     asserts:
@@ -24,21 +24,21 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: test-release
+          value: test-release-api
 
   - it: should reference the knative service
     documentIndex: 1
     asserts:
       - equal:
           path: spec.targetRef.name
-          value: test-release
+          value: test-release-api
 
   - it: should set analysis parameters
     set:
-      flagger.analysis.interval: 2m
-      flagger.analysis.threshold: 10
-      flagger.analysis.maxWeight: 80
-      flagger.analysis.stepWeight: 20
+      services.api.flagger.analysis.interval: 2m
+      services.api.flagger.analysis.threshold: 10
+      services.api.flagger.analysis.maxWeight: 80
+      services.api.flagger.analysis.stepWeight: 20
     documentIndex: 1
     asserts:
       - equal:
@@ -56,8 +56,8 @@ tests:
 
   - it: should set metric thresholds
     set:
-      flagger.metrics.successRateThreshold: 95
-      flagger.metrics.latencyP99ThresholdMs: 1000
+      services.api.flagger.metrics.successRateThreshold: 95
+      services.api.flagger.metrics.latencyP99ThresholdMs: 1000
     documentIndex: 1
     asserts:
       - equal:
@@ -69,7 +69,7 @@ tests:
 
   - it: should include webhooks when loadTest enabled
     set:
-      flagger.loadTest.enabled: true
+      services.api.flagger.loadTest.enabled: true
     documentIndex: 1
     asserts:
       - isNotNull:
@@ -77,7 +77,7 @@ tests:
 
   - it: should not render Canary when flagger disabled
     set:
-      flagger.enabled: false
+      services.api.flagger.enabled: false
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/library/ksvc/test-chart/tests/kafka-source_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/kafka-source_test.yaml
@@ -2,14 +2,17 @@ suite: kafka source tests
 templates:
   - templates/common.yaml
 set:
-  knativeService.image.repository: test/image
-  kafka.enabled: true
-  kafka.dlq.enabled: true
+  services.api.image.repository: test/image
+  kafka.sources.events.topic: "events"
+  kafka.sources.events.sink: api
+  kafka.sources.events.dlq.enabled: true
 release:
   name: test-release
   namespace: test-ns
 tests:
-  - it: should render KafkaSource when kafka enabled
+  # With one kafka source 'events' (+ DLQ enabled):
+  # doc 0 = Knative Service (api), doc 1 = KafkaSource (events), doc 2 = DLQ Service (events)
+  - it: should render KafkaSource when kafka source defined
     documentIndex: 1
     asserts:
       - isKind:
@@ -23,18 +26,18 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: test-release-kafka-source
+          value: test-release-events-kafka-source
 
   - it: should reference the knative service as sink
     documentIndex: 1
     asserts:
       - equal:
           path: spec.sink.ref.name
-          value: test-release
+          value: test-release-api
 
   - it: should set topic
     set:
-      kafka.source.topic: "my-events"
+      kafka.sources.events.topic: "my-events"
     documentIndex: 1
     asserts:
       - contains:
@@ -46,11 +49,11 @@ tests:
     asserts:
       - equal:
           path: spec.consumerGroup
-          value: test-release-consumers
+          value: test-release-events-consumers
 
   - it: should set custom consumer group
     set:
-      kafka.source.consumerGroup: "my-custom-group"
+      kafka.sources.events.consumerGroup: "my-custom-group"
     documentIndex: 1
     asserts:
       - equal:
@@ -64,18 +67,18 @@ tests:
           of: Service
       - equal:
           path: metadata.name
-          value: test-release-dlq
+          value: test-release-events-dlq
 
   - it: should set dead letter sink when DLQ enabled
     documentIndex: 1
     asserts:
       - equal:
           path: spec.delivery.deadLetterSink.ref.name
-          value: test-release-dlq
+          value: test-release-events-dlq
 
-  - it: should not render KafkaSource when kafka disabled
+  - it: should render only the service when no kafka sources defined
     set:
-      kafka.enabled: false
+      kafka.sources: null
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/library/ksvc/test-chart/tests/knative-service_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/knative-service_test.yaml
@@ -2,8 +2,8 @@ suite: knative service tests
 templates:
   - templates/common.yaml
 set:
-  knativeService.image.repository: test/image
-  knativeService.image.tag: "v1.0.0"
+  services.api.image.repository: test/image
+  services.api.image.tag: "v1.0.0"
 release:
   name: test-release
   namespace: test-ns
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: test-release
+          value: test-release-api
 
   - it: should set the correct namespace
     documentIndex: 0
@@ -33,9 +33,9 @@ tests:
 
   - it: should set scaling annotations
     set:
-      knativeService.scaling.minScale: 2
-      knativeService.scaling.maxScale: 20
-      knativeService.scaling.target: 50
+      services.api.scaling.minScale: 2
+      services.api.scaling.maxScale: 20
+      services.api.scaling.target: 50
     documentIndex: 0
     asserts:
       - equal:
@@ -50,8 +50,8 @@ tests:
 
   - it: should set resource limits
     set:
-      knativeService.resources.limits.cpu: "2"
-      knativeService.resources.limits.memory: "1Gi"
+      services.api.resources.limits.cpu: "2"
+      services.api.resources.limits.memory: "1Gi"
     documentIndex: 0
     asserts:
       - equal:
@@ -80,7 +80,7 @@ tests:
 
   - it: should include flux image policy comment when set
     set:
-      knativeService.image.fluxImagePolicy: "flux-system:my-service"
+      services.api.image.fluxImagePolicy: "flux-system:my-service"
     documentIndex: 0
     asserts:
       - matchRegex:
@@ -103,7 +103,7 @@ tests:
 
   - it: should set env vars when provided
     set:
-      knativeService.env:
+      services.api.env:
         - name: MY_VAR
           value: "hello"
     documentIndex: 0
@@ -112,7 +112,22 @@ tests:
           path: spec.template.spec.containers[0].env[0].name
           value: MY_VAR
 
-  - it: should render only one document when no features enabled
+  - it: should render only one document when single service and no features enabled
     asserts:
       - hasDocuments:
           count: 1
+
+  - it: should include component label
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: api
+
+  - it: should render multiple services
+    set:
+      services.api.image.repository: test/api
+      services.worker.image.repository: test/worker
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/library/ksvc/values.schema.json
+++ b/charts/library/ksvc/values.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ksvc Helm Chart Values",
-  "description": "Schema for ksvc Helm library chart values",
+  "description": "Schema for ksvc Helm library chart values — multi-service edition",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -9,185 +9,30 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "nameOverride": {
-          "type": "string"
-        },
-        "fullnameOverride": {
-          "type": "string"
-        },
-        "labels": {
-          "type": "object"
-        },
-        "annotations": {
-          "type": "object"
-        }
+        "nameOverride": { "type": "string" },
+        "fullnameOverride": { "type": "string" },
+        "labels": { "type": "object" },
+        "annotations": { "type": "object" }
       }
     },
-    "knativeService": {
+    "services": {
+      "type": "object",
+      "description": "Map of Knative Services. Each key becomes a name suffix: <release-name>-<key>",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/serviceEntry"
+      }
+    },
+    "kafka": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["image"],
       "properties": {
-        "image": {
+        "sources": {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["repository"],
-          "properties": {
-            "repository": {
-              "type": "string"
-            },
-            "tag": {
-              "type": "string"
-            },
-            "pullPolicy": {
-              "type": "string",
-              "enum": ["Always", "IfNotPresent", "Never"]
-            },
-            "fluxImagePolicy": {
-              "type": "string"
-            }
+          "description": "Map of KafkaSource entries. Each key becomes: <release-name>-<key>-kafka-source",
+          "additionalProperties": {
+            "$ref": "#/$defs/kafkaSourceEntry"
           }
-        },
-        "scaling": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "minScale": {
-              "type": "integer",
-              "minimum": 0
-            },
-            "maxScale": {
-              "type": "integer",
-              "minimum": 1
-            },
-            "target": {
-              "type": "integer",
-              "minimum": 1
-            },
-            "containerConcurrency": {
-              "type": "integer",
-              "minimum": 0
-            },
-            "timeoutSeconds": {
-              "type": "integer",
-              "minimum": 1
-            },
-            "class": {
-              "type": "string"
-            }
-          }
-        },
-        "resources": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "cpu": { "type": "string" },
-                "memory": { "type": "string" }
-              }
-            },
-            "limits": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "cpu": { "type": "string" },
-                "memory": { "type": "string" }
-              }
-            }
-          }
-        },
-        "port": {
-          "type": "integer",
-          "const": 8080
-        },
-        "probes": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "liveness": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "path": { "type": "string" },
-                "port": { "type": "integer" },
-                "initialDelaySeconds": { "type": "integer", "minimum": 0 },
-                "periodSeconds": { "type": "integer", "minimum": 1 },
-                "timeoutSeconds": { "type": "integer", "minimum": 1 },
-                "failureThreshold": { "type": "integer", "minimum": 1 }
-              }
-            },
-            "readiness": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "path": { "type": "string" },
-                "port": { "type": "integer" },
-                "initialDelaySeconds": { "type": "integer", "minimum": 0 },
-                "periodSeconds": { "type": "integer", "minimum": 1 },
-                "timeoutSeconds": { "type": "integer", "minimum": 1 },
-                "failureThreshold": { "type": "integer", "minimum": 1 }
-              }
-            }
-          }
-        },
-        "env": {
-          "type": "array"
-        },
-        "envFrom": {
-          "type": "array"
-        },
-        "securityContext": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "runAsNonRoot": { "type": "boolean" },
-            "runAsUser": { "type": "integer" },
-            "readOnlyRootFilesystem": { "type": "boolean" },
-            "allowPrivilegeEscalation": { "type": "boolean" },
-            "seccompProfile": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": ["RuntimeDefault", "Localhost", "Unconfined"]
-                },
-                "localhostProfile": { "type": "string" }
-              }
-            },
-            "capabilities": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "drop": {
-                  "type": "array",
-                  "items": { "type": "string" }
-                },
-                "add": {
-                  "type": "array",
-                  "items": { "type": "string" }
-                }
-              }
-            }
-          }
-        },
-        "volumeMounts": {
-          "type": "array"
-        },
-        "volumes": {
-          "type": "array"
-        },
-        "podAnnotations": {
-          "type": "object"
-        },
-        "annotations": {
-          "type": "object"
-        },
-        "labels": {
-          "type": "object"
         }
       }
     },
@@ -195,9 +40,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
+        "enabled": { "type": "boolean" },
         "version": {
           "type": "string",
           "enum": ["14", "15", "16", "17"]
@@ -207,9 +50,7 @@
           "minimum": 1,
           "maximum": 16
         },
-        "parameters": {
-          "type": "object"
-        },
+        "parameters": { "type": "object" },
         "sharedPreloadLibraries": {
           "type": "array",
           "items": { "type": "string" }
@@ -218,28 +59,7 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "resources": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "cpu": { "type": "string" },
-                "memory": { "type": "string" }
-              }
-            },
-            "limits": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "cpu": { "type": "string" },
-                "memory": { "type": "string" }
-              }
-            }
-          }
-        },
+        "resources": { "$ref": "#/$defs/resources" },
         "storage": {
           "type": "object",
           "additionalProperties": false,
@@ -248,9 +68,7 @@
               "type": "string",
               "pattern": "^[0-9]+[KMGT]i$"
             },
-            "storageClassName": {
-              "type": "string"
-            }
+            "storageClassName": { "type": "string" }
           }
         },
         "pooler": {
@@ -267,31 +85,8 @@
               "type": "string",
               "enum": ["transaction", "session", "statement"]
             },
-            "parameters": {
-              "type": "object"
-            },
-            "resources": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "requests": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "cpu": { "type": "string" },
-                    "memory": { "type": "string" }
-                  }
-                },
-                "limits": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "cpu": { "type": "string" },
-                    "memory": { "type": "string" }
-                  }
-                }
-              }
-            }
+            "parameters": { "type": "object" },
+            "resources": { "$ref": "#/$defs/resources" }
           }
         },
         "backup": {
@@ -364,103 +159,13 @@
         }
       }
     },
-    "kafka": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "source": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "topic": { "type": "string" },
-            "consumerGroup": { "type": "string" },
-            "bootstrapServers": {
-              "type": "array",
-              "minItems": 1,
-              "items": { "type": "string" }
-            },
-            "consumers": { "type": "integer", "minimum": 1 },
-            "initialOffset": {
-              "type": "string",
-              "enum": ["latest", "earliest"]
-            }
-          }
-        },
-        "delivery": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "retry": { "type": "integer", "minimum": 0 },
-            "backoffPolicy": {
-              "type": "string",
-              "enum": ["linear", "exponential"]
-            },
-            "backoffDelay": { "type": "string" }
-          }
-        },
-        "dlq": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "image": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "repository": { "type": "string" },
-                "tag": { "type": "string" }
-              }
-            },
-            "scaling": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "minScale": { "type": "integer", "minimum": 0 },
-                "maxScale": { "type": "integer", "minimum": 1 }
-              }
-            },
-            "resources": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "requests": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "cpu": { "type": "string" },
-                    "memory": { "type": "string" }
-                  }
-                },
-                "limits": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "cpu": { "type": "string" },
-                    "memory": { "type": "string" }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "dragonfly": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "image": {
-          "type": "string"
-        },
-        "imageTag": {
-          "type": "string"
-        },
+        "enabled": { "type": "boolean" },
+        "image": { "type": "string" },
+        "imageTag": { "type": "string" },
         "replicas": {
           "type": "integer",
           "minimum": 1,
@@ -470,31 +175,8 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "env": {
-          "type": "array"
-        },
-        "resources": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "cpu": { "type": "string" },
-                "memory": { "type": "string" }
-              }
-            },
-            "limits": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "cpu": { "type": "string" },
-                "memory": { "type": "string" }
-              }
-            }
-          }
-        },
+        "env": { "type": "array" },
+        "resources": { "$ref": "#/$defs/resources" },
         "authentication": {
           "type": "object",
           "additionalProperties": false,
@@ -564,88 +246,259 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "minAvailable": {
-              "type": "integer",
-              "minimum": 0
-            },
-            "maxUnavailable": {
-              "type": "integer",
-              "minimum": 0
-            }
+            "minAvailable": { "type": "integer", "minimum": 0 },
+            "maxUnavailable": { "type": "integer", "minimum": 0 }
           }
         },
         "affinity": { "type": "object" },
-        "tolerations": {
-          "type": "array"
-        },
-        "topologySpreadConstraints": {
-          "type": "array"
-        },
+        "tolerations": { "type": "array" },
+        "topologySpreadConstraints": { "type": "array" },
         "nodeSelector": { "type": "object" },
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },
         "serviceAccountName": { "type": "string" },
         "priorityClassName": { "type": "string" }
       }
-    },
-    "flagger": {
+    }
+  },
+  "required": ["services"],
+  "$defs": {
+    "resources": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "analysis": {
+        "requests": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "interval": { "type": "string" },
-            "threshold": { "type": "integer", "minimum": 1 },
-            "maxWeight": {
-              "type": "integer",
-              "minimum": 10,
-              "maximum": 100
-            },
-            "stepWeight": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 50
-            },
-            "progressDeadlineSeconds": { "type": "integer", "minimum": 1 }
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
           }
         },
-        "metrics": {
+        "limits": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "successRateThreshold": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 100
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    },
+    "serviceEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repository"],
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
             },
-            "latencyP99ThresholdMs": { "type": "integer", "minimum": 1 },
-            "prometheusAddress": { "type": "string" }
+            "fluxImagePolicy": { "type": "string" }
           }
         },
-        "loadTest": {
+        "scaling": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "minScale": { "type": "integer", "minimum": 0 },
+            "maxScale": { "type": "integer", "minimum": 1 },
+            "target": { "type": "integer", "minimum": 1 },
+            "containerConcurrency": { "type": "integer", "minimum": 0 },
+            "timeoutSeconds": { "type": "integer", "minimum": 1 },
+            "class": { "type": "string" }
+          }
+        },
+        "resources": { "$ref": "#/$defs/resources" },
+        "port": {
+          "type": "integer",
+          "const": 8080
+        },
+        "probes": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "liveness": { "$ref": "#/$defs/probe" },
+            "readiness": { "$ref": "#/$defs/probe" }
+          }
+        },
+        "env": { "type": "array" },
+        "envFrom": { "type": "array" },
+        "securityContext": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "runAsNonRoot": { "type": "boolean" },
+            "runAsUser": { "type": "integer" },
+            "readOnlyRootFilesystem": { "type": "boolean" },
+            "allowPrivilegeEscalation": { "type": "boolean" },
+            "seccompProfile": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["RuntimeDefault", "Localhost", "Unconfined"]
+                },
+                "localhostProfile": { "type": "string" }
+              }
+            },
+            "capabilities": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "add": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "volumeMounts": { "type": "array" },
+        "volumes": { "type": "array" },
+        "podAnnotations": { "type": "object" },
+        "annotations": { "type": "object" },
+        "labels": { "type": "object" },
+        "flagger": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "enabled": { "type": "boolean" },
-            "webhookUrl": { "type": "string" },
-            "vus": { "type": "integer", "minimum": 1 },
-            "duration": { "type": "string" },
-            "p95ThresholdMs": { "type": "integer", "minimum": 1 },
-            "errorRateThreshold": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 1
+            "analysis": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "interval": { "type": "string" },
+                "threshold": { "type": "integer", "minimum": 1 },
+                "maxWeight": {
+                  "type": "integer",
+                  "minimum": 10,
+                  "maximum": 100
+                },
+                "stepWeight": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 50
+                },
+                "progressDeadlineSeconds": { "type": "integer", "minimum": 1 }
+              }
             },
-            "script": { "type": "string" }
+            "metrics": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "successRateThreshold": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "latencyP99ThresholdMs": { "type": "integer", "minimum": 1 },
+                "prometheusAddress": { "type": "string" }
+              }
+            },
+            "loadTest": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "webhookUrl": { "type": "string" },
+                "vus": { "type": "integer", "minimum": 1 },
+                "duration": { "type": "string" },
+                "p95ThresholdMs": { "type": "integer", "minimum": 1 },
+                "errorRateThreshold": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                "script": { "type": "string" }
+              }
+            }
           }
         }
       }
+    },
+    "kafkaSourceEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["topic", "sink"],
+      "properties": {
+        "topic": { "type": "string" },
+        "consumerGroup": { "type": "string" },
+        "bootstrapServers": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "consumers": { "type": "integer", "minimum": 1 },
+        "initialOffset": {
+          "type": "string",
+          "enum": ["latest", "earliest"]
+        },
+        "sink": {
+          "type": "string",
+          "description": "Must reference a key in the services map"
+        },
+        "delivery": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "retry": { "type": "integer", "minimum": 0 },
+            "backoffPolicy": {
+              "type": "string",
+              "enum": ["linear", "exponential"]
+            },
+            "backoffDelay": { "type": "string" }
+          }
+        },
+        "dlq": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string" }
+              }
+            },
+            "scaling": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "minScale": { "type": "integer", "minimum": 0 },
+                "maxScale": { "type": "integer", "minimum": 1 }
+              }
+            },
+            "resources": { "$ref": "#/$defs/resources" }
+          }
+        }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": { "type": "string" },
+        "port": { "type": "integer" },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
     }
-  },
-  "required": ["knativeService"]
+  }
 }

--- a/charts/library/ksvc/values.yaml
+++ b/charts/library/ksvc/values.yaml
@@ -13,93 +13,129 @@ global:
   annotations: {}
 
 # =============================================================================
-# Knative Service
+# Services — Map of Knative Services (one or more)
+#
+# Each key becomes a name suffix: <release-name>-<key>
+# Example:
+#   services:
+#     api:
+#       image: { repository: ghcr.io/org/api, tag: v1.0.0 }
+#     worker:
+#       image: { repository: ghcr.io/org/worker, tag: v1.0.0 }
 # =============================================================================
-knativeService:
-  # Container image configuration
-  image:
-    repository: ""
-    tag: "latest"
-    pullPolicy: IfNotPresent
-    # Flux image policy annotation
-    fluxImagePolicy: ""
+services:
+  api:
+    # Container image configuration
+    image:
+      repository: ""
+      tag: "latest"
+      pullPolicy: IfNotPresent
+      # Flux image policy annotation
+      fluxImagePolicy: ""
 
-  # Knative autoscaling
-  scaling:
-    minScale: 1
-    maxScale: 10
-    target: 100
-    containerConcurrency: 100
-    timeoutSeconds: 300
-    class: ""
+    # Knative autoscaling
+    scaling:
+      minScale: 1
+      maxScale: 10
+      target: 100
+      containerConcurrency: 100
+      timeoutSeconds: 300
+      class: ""
 
-  # Container resources
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "64Mi"
-    limits:
-      cpu: "500m"
-      memory: "256Mi"
+    # Container resources
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
 
-  # Container port
-  port: 8080
+    # Container port
+    port: 8080
 
-  # Health probes
-  probes:
-    liveness:
-      path: /health/live
-      port: 8080
-      initialDelaySeconds: 3
-      periodSeconds: 10
-      timeoutSeconds: 2
-      failureThreshold: 3
-    readiness:
-      path: /health/ready
-      port: 8080
-      initialDelaySeconds: 5
-      periodSeconds: 5
-      timeoutSeconds: 3
-      failureThreshold: 2
+    # Health probes
+    probes:
+      liveness:
+        path: /health/live
+        port: 8080
+        initialDelaySeconds: 3
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+      readiness:
+        path: /health/ready
+        port: 8080
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 2
 
-  # Environment variables
-  env: []
+    # Environment variables
+    env: []
 
-  # Environment variables from ConfigMaps or Secrets
-  envFrom: []
+    # Environment variables from ConfigMaps or Secrets
+    envFrom: []
 
-  # Security context for the container
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 10001
-    readOnlyRootFilesystem: true
-    allowPrivilegeEscalation: false
-    seccompProfile:
-      type: RuntimeDefault
-    capabilities:
-      drop:
-        - ALL
+    # Security context for the container
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 10001
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
 
-  # Additional volume mounts
-  volumeMounts: []
+    # Additional volume mounts
+    volumeMounts: []
 
-  # Additional volumes
-  volumes: []
+    # Additional volumes
+    volumes: []
 
-  # Pod-level annotations
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
-    prometheus.io/path: "/metrics"
+    # Pod-level annotations
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
 
-  # Service-level annotations
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
-    prometheus.io/path: "/metrics"
+    # Service-level annotations
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
 
-  # Service-level labels
-  labels: {}
+    # Service-level labels
+    labels: {}
+
+    # Flagger Canary Release (per-service opt-in)
+    flagger:
+      enabled: false
+
+      analysis:
+        interval: 1m
+        threshold: 5
+        maxWeight: 50
+        stepWeight: 10
+        progressDeadlineSeconds: 120
+
+      metrics:
+        successRateThreshold: 99
+        latencyP99ThresholdMs: 500
+        prometheusAddress: http://prometheus.observability.svc.cluster.local:9090
+
+      loadTest:
+        enabled: true
+        # URL of the k6 webhook service (grafana/flagger-k6-webhook)
+        webhookUrl: http://k6-loadtester.flagger-system/launch-test
+        vus: 10
+        duration: 1m
+        p95ThresholdMs: 500
+        errorRateThreshold: 0.01
+        # Optional: override the entire k6 script
+        script: ""
 
 # =============================================================================
 # CloudNativePG PostgreSQL
@@ -192,39 +228,22 @@ postgres:
       highConnectionCount: 50
 
 # =============================================================================
-# Kafka Event Source
+# Kafka Event Sources — Map of KafkaSource entries
+#
+# Each key becomes a name suffix: <release-name>-<key>-kafka-source
+# The "sink" field must reference a key in the services map.
+# Example:
+#   kafka:
+#     sources:
+#       events:
+#         topic: my-events
+#         sink: api
+#       commands:
+#         topic: my-commands
+#         sink: worker
 # =============================================================================
 kafka:
-  enabled: false
-
-  source:
-    topic: "events"
-    consumerGroup: ""
-    bootstrapServers:
-      - kafka.kafka.svc.cluster.local:9092
-    consumers: 3
-    initialOffset: latest
-
-  delivery:
-    retry: 5
-    backoffPolicy: exponential
-    backoffDelay: PT1S
-
-  dlq:
-    enabled: true
-    image:
-      repository: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display
-      tag: latest
-    scaling:
-      minScale: 0
-      maxScale: 2
-    resources:
-      requests:
-        cpu: "50m"
-        memory: "32Mi"
-      limits:
-        cpu: "200m"
-        memory: "128Mi"
+  sources: {}
 
 # =============================================================================
 # DragonflyDB Cache Cluster
@@ -310,32 +329,3 @@ dragonfly:
 
   # Priority class
   priorityClassName: ""
-
-# =============================================================================
-# Flagger Canary Release
-# =============================================================================
-flagger:
-  enabled: false
-
-  analysis:
-    interval: 1m
-    threshold: 5
-    maxWeight: 50
-    stepWeight: 10
-    progressDeadlineSeconds: 120
-
-  metrics:
-    successRateThreshold: 99
-    latencyP99ThresholdMs: 500
-    prometheusAddress: http://prometheus.observability.svc.cluster.local:9090
-
-  loadTest:
-    enabled: true
-    # URL of the k6 webhook service (grafana/flagger-k6-webhook)
-    webhookUrl: http://k6-loadtester.flagger-system/launch-test
-    vus: 10
-    duration: 1m
-    p95ThresholdMs: 500
-    errorRateThreshold: 0.01
-    # Optional: override the entire k6 script
-    script: ""

--- a/examples/dragonfly-cache/values.yaml
+++ b/examples/dragonfly-cache/values.yaml
@@ -1,34 +1,26 @@
-knativeService:
-  image:
-    repository: ghcr.io/example-org/cache-service
-    tag: "v1.0.0"
-  scaling:
-    minScale: 1
-    maxScale: 10
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "128Mi"
-    limits:
-      cpu: "500m"
-      memory: "512Mi"
-  env:
-    - name: APP__CACHE__URL
-      valueFrom:
-        secretKeyRef:
-          name: cache-service-dragonfly-auth
-          key: url
-    - name: APP__TELEMETRY__OTLP_ENDPOINT
-      value: "http://otel-collector.observability.svc.cluster.local:4317"
-
-postgres:
-  enabled: false
-
-kafka:
-  enabled: false
-
-flagger:
-  enabled: false
+services:
+  api:
+    image:
+      repository: ghcr.io/example-org/cache-service
+      tag: "v1.0.0"
+    scaling:
+      minScale: 1
+      maxScale: 10
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+    env:
+      - name: APP__CACHE__URL
+        valueFrom:
+          secretKeyRef:
+            name: cache-service-dragonfly-auth
+            key: url
+      - name: APP__TELEMETRY__OTLP_ENDPOINT
+        value: "http://otel-collector.observability.svc.cluster.local:4317"
 
 dragonfly:
   enabled: true

--- a/examples/full-stack/values.yaml
+++ b/examples/full-stack/values.yaml
@@ -1,29 +1,46 @@
-knativeService:
-  image:
-    repository: ghcr.io/example-org/full-stack-service
-    tag: "v2.0.0"
-    fluxImagePolicy: "flux-system:full-stack-service"
-  scaling:
-    minScale: 2
-    maxScale: 20
-    target: 100
-  resources:
-    requests:
-      cpu: "250m"
-      memory: "256Mi"
-    limits:
-      cpu: "1000m"
-      memory: "512Mi"
-  env:
-    - name: APP__REDIS__URL
-      valueFrom:
-        secretKeyRef:
-          name: full-stack-service-secrets
-          key: redis-url
-    - name: APP__TELEMETRY__OTLP_ENDPOINT
-      value: "http://otel-collector.observability.svc.cluster.local:4317"
-    - name: APP__TELEMETRY__SERVICE_NAME
-      value: "full-stack-service"
+services:
+  api:
+    image:
+      repository: ghcr.io/example-org/full-stack-service
+      tag: "v2.0.0"
+      fluxImagePolicy: "flux-system:full-stack-service"
+    scaling:
+      minScale: 2
+      maxScale: 20
+      target: 100
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "256Mi"
+      limits:
+        cpu: "1000m"
+        memory: "512Mi"
+    env:
+      - name: APP__REDIS__URL
+        valueFrom:
+          secretKeyRef:
+            name: full-stack-service-secrets
+            key: redis-url
+      - name: APP__TELEMETRY__OTLP_ENDPOINT
+        value: "http://otel-collector.observability.svc.cluster.local:4317"
+      - name: APP__TELEMETRY__SERVICE_NAME
+        value: "full-stack-service"
+    flagger:
+      enabled: true
+      analysis:
+        interval: 1m
+        threshold: 5
+        maxWeight: 50
+        stepWeight: 10
+      metrics:
+        successRateThreshold: 99
+        latencyP99ThresholdMs: 500
+        prometheusAddress: http://prometheus.observability.svc.cluster.local:9090
+      loadTest:
+        enabled: true
+        webhookUrl: http://k6-loadtester.flagger-system/launch-test
+        vus: 10
+        duration: 1m
 
 postgres:
   enabled: true
@@ -68,37 +85,21 @@ postgres:
       highConnectionCount: 50
 
 kafka:
-  enabled: true
-  source:
-    topic: "full-stack-events"
-    consumerGroup: "full-stack-service-consumers"
-    bootstrapServers:
-      - kafka.prod.svc.cluster.local:9092
-    consumers: 10
-    initialOffset: latest
-  delivery:
-    retry: 10
-    backoffPolicy: exponential
-    backoffDelay: PT2S
-  dlq:
-    enabled: true
-
-flagger:
-  enabled: true
-  analysis:
-    interval: 1m
-    threshold: 5
-    maxWeight: 50
-    stepWeight: 10
-  metrics:
-    successRateThreshold: 99
-    latencyP99ThresholdMs: 500
-    prometheusAddress: http://prometheus.observability.svc.cluster.local:9090
-  loadTest:
-    enabled: true
-    webhookUrl: http://k6-loadtester.flagger-system/launch-test
-    vus: 10
-    duration: 1m
+  sources:
+    events:
+      topic: "full-stack-events"
+      consumerGroup: "full-stack-service-consumers"
+      sink: api
+      bootstrapServers:
+        - kafka.prod.svc.cluster.local:9092
+      consumers: 10
+      initialOffset: latest
+      delivery:
+        retry: 10
+        backoffPolicy: exponential
+        backoffDelay: PT2S
+      dlq:
+        enabled: true
 
 dragonfly:
   enabled: true

--- a/examples/kafka-consumer/values.yaml
+++ b/examples/kafka-consumer/values.yaml
@@ -1,36 +1,32 @@
-knativeService:
-  image:
-    repository: ghcr.io/example-org/event-processor
-    tag: "v3.0.0"
-  scaling:
-    minScale: 0
-    maxScale: 50
-    target: 10
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "64Mi"
-    limits:
-      cpu: "500m"
-      memory: "256Mi"
-  env:
-    - name: APP__REDIS__URL
-      value: "redis://redis:6379"
+services:
+  processor:
+    image:
+      repository: ghcr.io/example-org/event-processor
+      tag: "v3.0.0"
+    scaling:
+      minScale: 0
+      maxScale: 50
+      target: 10
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+    env:
+      - name: APP__REDIS__URL
+        value: "redis://redis:6379"
 
 kafka:
-  enabled: true
-  source:
-    topic: "incoming-events"
-    consumerGroup: "event-processor-group"
-    bootstrapServers:
-      - kafka.kafka.svc.cluster.local:9092
-    consumers: 5
-    initialOffset: earliest
-  dlq:
-    enabled: true
-
-postgres:
-  enabled: false
-
-flagger:
-  enabled: false
+  sources:
+    events:
+      topic: "incoming-events"
+      consumerGroup: "event-processor-group"
+      sink: processor
+      bootstrapServers:
+        - kafka.kafka.svc.cluster.local:9092
+      consumers: 5
+      initialOffset: earliest
+      dlq:
+        enabled: true

--- a/examples/minimal/values.yaml
+++ b/examples/minimal/values.yaml
@@ -1,28 +1,20 @@
-knativeService:
-  image:
-    repository: ghcr.io/example-org/minimal-service
-    tag: "v1.0.0"
-  scaling:
-    minScale: 1
-    maxScale: 5
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "64Mi"
-    limits:
-      cpu: "500m"
-      memory: "256Mi"
-  env:
-    - name: APP__REDIS__URL
-      value: "redis://redis:6379"
-    - name: APP__TELEMETRY__OTLP_ENDPOINT
-      value: "http://otel-collector.observability.svc.cluster.local:4317"
-
-postgres:
-  enabled: false
-
-kafka:
-  enabled: false
-
-flagger:
-  enabled: false
+services:
+  api:
+    image:
+      repository: ghcr.io/example-org/minimal-service
+      tag: "v1.0.0"
+    scaling:
+      minScale: 1
+      maxScale: 5
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+    env:
+      - name: APP__REDIS__URL
+        value: "redis://redis:6379"
+      - name: APP__TELEMETRY__OTLP_ENDPOINT
+        value: "http://otel-collector.observability.svc.cluster.local:4317"

--- a/examples/postgres-only/values.yaml
+++ b/examples/postgres-only/values.yaml
@@ -1,25 +1,26 @@
-knativeService:
-  image:
-    repository: ghcr.io/example-org/api-service
-    tag: "v1.5.0"
-  scaling:
-    minScale: 1
-    maxScale: 10
-  resources:
-    requests:
-      cpu: "200m"
-      memory: "128Mi"
-    limits:
-      cpu: "800m"
-      memory: "384Mi"
-  env:
-    - name: APP__REDIS__URL
-      valueFrom:
-        secretKeyRef:
-          name: api-service-secrets
-          key: redis-url
-    - name: APP__TELEMETRY__OTLP_ENDPOINT
-      value: "http://otel-collector.observability.svc.cluster.local:4317"
+services:
+  api:
+    image:
+      repository: ghcr.io/example-org/api-service
+      tag: "v1.5.0"
+    scaling:
+      minScale: 1
+      maxScale: 10
+    resources:
+      requests:
+        cpu: "200m"
+        memory: "128Mi"
+      limits:
+        cpu: "800m"
+        memory: "384Mi"
+    env:
+      - name: APP__REDIS__URL
+        valueFrom:
+          secretKeyRef:
+            name: api-service-secrets
+            key: redis-url
+      - name: APP__TELEMETRY__OTLP_ENDPOINT
+        value: "http://otel-collector.observability.svc.cluster.local:4317"
 
 postgres:
   enabled: true
@@ -37,9 +38,3 @@ postgres:
       endpointURL: "http://minio.minio.svc.cluster.local:9000"
   monitoring:
     enabled: true
-
-kafka:
-  enabled: false
-
-flagger:
-  enabled: false


### PR DESCRIPTION
## Summary

- Refactors the `ksvc` Helm library chart from a single-service architecture (`knativeService:`) to a multi-service map (`services:`)
- Each map key becomes a named Knative Service: `<release>-<key>`
- Flagger canary config moves inside each service entry as `services.<key>.flagger.enabled`
- Kafka sources become a map under `kafka.sources:` with explicit `sink` references validated against the services map
- Per-source DLQ opt-in replaces the global DLQ
- PostgreSQL and DragonflyDB remain global shared resources

## Breaking Changes

| v0.1.x | v0.2.0 |
|--------|--------|
| `knativeService.*` | `services.<key>.*` |
| `flagger.enabled` | `services.<key>.flagger.enabled` |
| `kafka.enabled` / `kafka.source.*` | `kafka.sources.<key>.*` with explicit `sink` |

## Changes

- **Templates**: Added `ksvc.serviceName` and `ksvc.serviceLabels` helpers; refactored all class templates to accept dict context (`root`, `key`, `svc`/`source`)
- **Loader**: Rewrote `_generate.tpl` with services/kafka iteration and nil-safety
- **Validators**: Services map validation and kafka sink-to-service resolution
- **Schema**: `values.schema.json` rewritten with `services` as `additionalProperties` map, `kafka.sources` map, `$defs` for shared types
- **Tests**: All 6 test suites updated (60/60 passing)
- **Examples**: All 5 example values.yaml files migrated
- **Docs**: README updated with new API reference, architecture diagram, naming conventions, and migration guide