### PR TITLE
ci: harden integration tests with retry logic and namespace fix

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -69,37 +69,61 @@ jobs:
 
       - name: Install Knative Serving CRDs
         run: |
-          kubectl apply --server-side -f https://github.com/knative/serving/releases/download/knative-v1.17.0/serving-crds.yaml
+          for i in 1 2 3; do
+            kubectl apply --server-side -f https://github.com/knative/serving/releases/download/knative-v1.17.0/serving-crds.yaml && break
+            echo "Attempt $i failed, retrying in 5s..." && sleep 5
+          done
           kubectl wait --for=condition=Established crd/services.serving.knative.dev --timeout=60s
 
       - name: Install CNPG CRDs
         if: matrix.install_cnpg_crds
         run: |
-          kubectl apply --server-side -f https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/config/crd/bases/postgresql.cnpg.io_clusters.yaml
-          kubectl apply --server-side -f https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/config/crd/bases/postgresql.cnpg.io_poolers.yaml
-          kubectl apply --server-side -f https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/config/crd/bases/postgresql.cnpg.io_scheduledbackups.yaml
-          kubectl apply --server-side -f https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/main/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
+          for url in \
+            https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/config/crd/bases/postgresql.cnpg.io_clusters.yaml \
+            https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/config/crd/bases/postgresql.cnpg.io_poolers.yaml \
+            https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/config/crd/bases/postgresql.cnpg.io_scheduledbackups.yaml \
+            https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/main/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml; do
+            for i in 1 2 3; do
+              kubectl apply --server-side -f "$url" && break
+              echo "Attempt $i failed for $url, retrying in 5s..." && sleep 5
+            done
+          done
 
       - name: Install Prometheus Operator CRDs
         if: matrix.install_monitoring_crds
         run: |
-          kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-          kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+          for url in \
+            https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml \
+            https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml; do
+            for i in 1 2 3; do
+              kubectl apply --server-side -f "$url" && break
+              echo "Attempt $i failed for $url, retrying in 5s..." && sleep 5
+            done
+          done
 
       - name: Install Flagger CRDs
         if: matrix.install_flagger_crds
         run: |
-          kubectl apply --server-side -f https://raw.githubusercontent.com/fluxcd/flagger/main/artifacts/flagger/crd.yaml
+          for i in 1 2 3; do
+            kubectl apply --server-side -f https://raw.githubusercontent.com/fluxcd/flagger/main/artifacts/flagger/crd.yaml && break
+            echo "Attempt $i failed, retrying in 5s..." && sleep 5
+          done
 
       - name: Install Kafka CRDs
         if: matrix.install_kafka_crds
         run: |
-          kubectl apply --server-side -f https://raw.githubusercontent.com/knative-extensions/eventing-kafka-broker/knative-v1.17.0/control-plane/config/eventing-kafka-broker/100-source/100-kafka-source.yaml
+          for i in 1 2 3; do
+            kubectl apply --server-side -f https://raw.githubusercontent.com/knative-extensions/eventing-kafka-broker/knative-v1.17.0/control-plane/config/eventing-kafka-broker/100-source/100-kafka-source.yaml && break
+            echo "Attempt $i failed, retrying in 5s..." && sleep 5
+          done
 
       - name: Install DragonflyDB CRDs
         if: matrix.install_dragonfly_crds
         run: |
-          kubectl apply --server-side -f https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/main/config/crd/bases/dragonflydb.io_dragonflies.yaml
+          for i in 1 2 3; do
+            kubectl apply --server-side -f https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/main/config/crd/bases/dragonflydb.io_dragonflies.yaml && break
+            echo "Attempt $i failed, retrying in 5s..." && sleep 5
+          done
 
       - name: Helm dependency update
         run: helm dependency update examples/${{ matrix.example }}
@@ -114,6 +138,7 @@ jobs:
 
       - name: Verify rendered resources via kubectl
         run: |
+          kubectl create namespace test-ns --dry-run=client -o yaml | kubectl apply -f -
           helm template test-release examples/${{ matrix.example }} \
             --namespace test-ns | \
             kubectl apply --dry-run=server -f - 2>&1 || true
@@ -135,7 +160,10 @@ jobs:
 
       - name: Install Knative Serving CRDs
         run: |
-          kubectl apply --server-side -f https://github.com/knative/serving/releases/download/knative-v1.17.0/serving-crds.yaml
+          for i in 1 2 3; do
+            kubectl apply --server-side -f https://github.com/knative/serving/releases/download/knative-v1.17.0/serving-crds.yaml && break
+            echo "Attempt $i failed, retrying in 5s..." && sleep 5
+          done
           kubectl wait --for=condition=Established crd/services.serving.knative.dev --timeout=60s
 
       - name: Resolve app chart dependency locally

--- a/charts/library/ksvc/templates/classes/_cert-manager-dragonfly.tpl
+++ b/charts/library/ksvc/templates/classes/_cert-manager-dragonfly.tpl
@@ -1,12 +1,12 @@
 {{- define "ksvc.class.certManagerDragonfly" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
 {{- $df := .Values.dragonfly -}}
 {{- $cm := $df.tls.certManager -}}
 {{- $globalCM := .Values.global.certManager -}}
 {{- $issuerName := $cm.issuerRef.name | default $globalCM.issuerRef.name -}}
 {{- $issuerKind := $cm.issuerRef.kind | default $globalCM.issuerRef.kind -}}
 {{- $issuerGroup := $cm.issuerRef.group | default $globalCM.issuerRef.group -}}
-{{- $secretName := printf "%s-dragonfly-server-tls" $fullname -}}
+{{- $dfName := include "ksvc.dragonflyName" . -}}
+{{- $secretName := include "ksvc.dragonflyServerTLSSecret" . -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,7 +19,7 @@ metadata:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $fullname }}-dragonfly-server-cert
+  name: {{ $dfName }}-server-cert
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}
@@ -35,10 +35,10 @@ spec:
   usages:
     - server auth
   dnsNames:
-    - {{ $fullname }}-dragonfly
-    - {{ $fullname }}-dragonfly.{{ .Release.Namespace }}
-    - {{ $fullname }}-dragonfly.{{ .Release.Namespace }}.svc
-    - {{ $fullname }}-dragonfly.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ $dfName }}
+    - {{ $dfName }}.{{ .Release.Namespace }}
+    - {{ $dfName }}.{{ .Release.Namespace }}.svc
+    - {{ $dfName }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     name: {{ $issuerName }}
     kind: {{ $issuerKind }}

--- a/charts/library/ksvc/templates/classes/_cert-manager-dragonfly.tpl
+++ b/charts/library/ksvc/templates/classes/_cert-manager-dragonfly.tpl
@@ -1,0 +1,46 @@
+{{- define "ksvc.class.certManagerDragonfly" -}}
+{{- $fullname := include "ksvc.fullname" . -}}
+{{- $df := .Values.dragonfly -}}
+{{- $cm := $df.tls.certManager -}}
+{{- $globalCM := .Values.global.certManager -}}
+{{- $issuerName := $cm.issuerRef.name | default $globalCM.issuerRef.name -}}
+{{- $issuerKind := $cm.issuerRef.kind | default $globalCM.issuerRef.kind -}}
+{{- $issuerGroup := $cm.issuerRef.group | default $globalCM.issuerRef.group -}}
+{{- $secretName := printf "%s-dragonfly-server-tls" $fullname -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ksvc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cache
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullname }}-dragonfly-server-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ksvc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cache
+spec:
+  secretName: {{ $secretName }}
+  {{- if $cm.duration }}
+  duration: {{ $cm.duration }}
+  {{- end }}
+  {{- if $cm.renewBefore }}
+  renewBefore: {{ $cm.renewBefore }}
+  {{- end }}
+  usages:
+    - server auth
+  dnsNames:
+    - {{ $fullname }}-dragonfly
+    - {{ $fullname }}-dragonfly.{{ .Release.Namespace }}
+    - {{ $fullname }}-dragonfly.{{ .Release.Namespace }}.svc
+    - {{ $fullname }}-dragonfly.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    name: {{ $issuerName }}
+    kind: {{ $issuerKind }}
+    group: {{ $issuerGroup }}
+{{- end }}

--- a/charts/library/ksvc/templates/classes/_cert-manager-postgres.tpl
+++ b/charts/library/ksvc/templates/classes/_cert-manager-postgres.tpl
@@ -1,13 +1,13 @@
 {{- define "ksvc.class.certManagerPostgres" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
 {{- $pg := .Values.postgres -}}
 {{- $cm := $pg.certManager -}}
 {{- $globalCM := .Values.global.certManager -}}
 {{- $issuerName := $cm.issuerRef.name | default $globalCM.issuerRef.name -}}
 {{- $issuerKind := $cm.issuerRef.kind | default $globalCM.issuerRef.kind -}}
 {{- $issuerGroup := $cm.issuerRef.group | default $globalCM.issuerRef.group -}}
-{{- $serverSecretName := printf "%s-postgres-server-tls" $fullname -}}
-{{- $clientSecretName := printf "%s-postgres-client-tls" $fullname -}}
+{{- $pgName := include "ksvc.postgresName" . -}}
+{{- $serverSecretName := include "ksvc.postgresServerTLSSecret" . -}}
+{{- $clientSecretName := include "ksvc.postgresClientTLSSecret" . -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,7 +21,7 @@ metadata:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $fullname }}-postgres-server-cert
+  name: {{ $pgName }}-server-cert
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}
@@ -31,15 +31,15 @@ spec:
   usages:
     - server auth
   dnsNames:
-    - {{ $fullname }}-postgres-rw
-    - {{ $fullname }}-postgres-rw.{{ .Release.Namespace }}
-    - {{ $fullname }}-postgres-rw.{{ .Release.Namespace }}.svc
-    - {{ $fullname }}-postgres-r
-    - {{ $fullname }}-postgres-r.{{ .Release.Namespace }}
-    - {{ $fullname }}-postgres-r.{{ .Release.Namespace }}.svc
-    - {{ $fullname }}-postgres-ro
-    - {{ $fullname }}-postgres-ro.{{ .Release.Namespace }}
-    - {{ $fullname }}-postgres-ro.{{ .Release.Namespace }}.svc
+    - {{ $pgName }}-rw
+    - {{ $pgName }}-rw.{{ .Release.Namespace }}
+    - {{ $pgName }}-rw.{{ .Release.Namespace }}.svc
+    - {{ $pgName }}-r
+    - {{ $pgName }}-r.{{ .Release.Namespace }}
+    - {{ $pgName }}-r.{{ .Release.Namespace }}.svc
+    - {{ $pgName }}-ro
+    - {{ $pgName }}-ro.{{ .Release.Namespace }}
+    - {{ $pgName }}-ro.{{ .Release.Namespace }}.svc
   issuerRef:
     name: {{ $issuerName }}
     kind: {{ $issuerKind }}
@@ -58,7 +58,7 @@ metadata:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $fullname }}-postgres-client-cert
+  name: {{ $pgName }}-client-cert
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}

--- a/charts/library/ksvc/templates/classes/_cert-manager-postgres.tpl
+++ b/charts/library/ksvc/templates/classes/_cert-manager-postgres.tpl
@@ -1,0 +1,75 @@
+{{- define "ksvc.class.certManagerPostgres" -}}
+{{- $fullname := include "ksvc.fullname" . -}}
+{{- $pg := .Values.postgres -}}
+{{- $cm := $pg.certManager -}}
+{{- $globalCM := .Values.global.certManager -}}
+{{- $issuerName := $cm.issuerRef.name | default $globalCM.issuerRef.name -}}
+{{- $issuerKind := $cm.issuerRef.kind | default $globalCM.issuerRef.kind -}}
+{{- $issuerGroup := $cm.issuerRef.group | default $globalCM.issuerRef.group -}}
+{{- $serverSecretName := printf "%s-postgres-server-tls" $fullname -}}
+{{- $clientSecretName := printf "%s-postgres-client-tls" $fullname -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $serverSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ksvc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+    cnpg.io/reload: ""
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullname }}-postgres-server-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ksvc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  secretName: {{ $serverSecretName }}
+  usages:
+    - server auth
+  dnsNames:
+    - {{ $fullname }}-postgres-rw
+    - {{ $fullname }}-postgres-rw.{{ .Release.Namespace }}
+    - {{ $fullname }}-postgres-rw.{{ .Release.Namespace }}.svc
+    - {{ $fullname }}-postgres-r
+    - {{ $fullname }}-postgres-r.{{ .Release.Namespace }}
+    - {{ $fullname }}-postgres-r.{{ .Release.Namespace }}.svc
+    - {{ $fullname }}-postgres-ro
+    - {{ $fullname }}-postgres-ro.{{ .Release.Namespace }}
+    - {{ $fullname }}-postgres-ro.{{ .Release.Namespace }}.svc
+  issuerRef:
+    name: {{ $issuerName }}
+    kind: {{ $issuerKind }}
+    group: {{ $issuerGroup }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $clientSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ksvc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+    cnpg.io/reload: ""
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullname }}-postgres-client-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ksvc.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  secretName: {{ $clientSecretName }}
+  usages:
+    - client auth
+  commonName: streaming_replica
+  issuerRef:
+    name: {{ $issuerName }}
+    kind: {{ $issuerKind }}
+    group: {{ $issuerGroup }}
+{{- end }}

--- a/charts/library/ksvc/templates/classes/_cnpg-alerts.tpl
+++ b/charts/library/ksvc/templates/classes/_cnpg-alerts.tpl
@@ -1,14 +1,14 @@
 {{- define "ksvc.class.cnpgAlerts" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
+{{- $pgName := include "ksvc.postgresName" . -}}
 {{- $alerts := .Values.postgres.monitoring.alerts -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ $fullname }}-postgres-alerts
+  name: {{ $pgName }}-alerts
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}
-    app: {{ $fullname }}-postgres
+    app: {{ $pgName }}
     prometheus: kube-prometheus
 spec:
   groups:

--- a/charts/library/ksvc/templates/classes/_cnpg-backup.tpl
+++ b/charts/library/ksvc/templates/classes/_cnpg-backup.tpl
@@ -1,10 +1,10 @@
 {{- define "ksvc.class.cnpgScheduledBackup" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
 {{- $backup := .Values.postgres.backup -}}
+{{- $pgName := include "ksvc.postgresName" . -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: {{ $fullname }}-postgres-daily-backup
+  name: {{ $pgName }}-daily-backup
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}
@@ -15,8 +15,8 @@ spec:
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
     parameters:
-      barmanObjectName: {{ $fullname }}-postgres-backup-store
+      barmanObjectName: {{ include "ksvc.postgresBackupStoreName" . }}
   cluster:
-    name: {{ $fullname }}-postgres
+    name: {{ $pgName }}
   target: {{ $backup.target }}
 {{- end }}

--- a/charts/library/ksvc/templates/classes/_cnpg-cluster.tpl
+++ b/charts/library/ksvc/templates/classes/_cnpg-cluster.tpl
@@ -1,10 +1,10 @@
 {{- define "ksvc.class.cnpgCluster" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
 {{- $pg := .Values.postgres -}}
+{{- $pgName := include "ksvc.postgresName" . -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: {{ $fullname }}-postgres
+  name: {{ $pgName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}
@@ -30,7 +30,7 @@ spec:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
-        barmanObjectName: {{ $fullname }}-postgres-backup-store
+        barmanObjectName: {{ include "ksvc.postgresBackupStoreName" . }}
   {{- end }}
   bootstrap:
     initdb:
@@ -38,10 +38,10 @@ spec:
         {{- toYaml $pg.postInitSQL | nindent 8 }}
   {{- if and $pg.certManager $pg.certManager.enabled }}
   certificates:
-    serverTLSSecret: {{ $fullname }}-postgres-server-tls
-    serverCASecret: {{ $fullname }}-postgres-server-tls
-    clientCASecret: {{ $fullname }}-postgres-client-tls
-    replicationTLSSecret: {{ $fullname }}-postgres-client-tls
+    serverTLSSecret: {{ include "ksvc.postgresServerTLSSecret" . }}
+    serverCASecret: {{ include "ksvc.postgresServerTLSSecret" . }}
+    clientCASecret: {{ include "ksvc.postgresClientTLSSecret" . }}
+    replicationTLSSecret: {{ include "ksvc.postgresClientTLSSecret" . }}
   {{- end }}
   monitoring:
     enabled: {{ $pg.monitoring.enabled }}

--- a/charts/library/ksvc/templates/classes/_cnpg-cluster.tpl
+++ b/charts/library/ksvc/templates/classes/_cnpg-cluster.tpl
@@ -36,6 +36,13 @@ spec:
     initdb:
       postInitApplicationSQL:
         {{- toYaml $pg.postInitSQL | nindent 8 }}
+  {{- if and $pg.certManager $pg.certManager.enabled }}
+  certificates:
+    serverTLSSecret: {{ $fullname }}-postgres-server-tls
+    serverCASecret: {{ $fullname }}-postgres-server-tls
+    clientCASecret: {{ $fullname }}-postgres-client-tls
+    replicationTLSSecret: {{ $fullname }}-postgres-client-tls
+  {{- end }}
   monitoring:
     enabled: {{ $pg.monitoring.enabled }}
     podMonitorEnabled: {{ $pg.monitoring.enabled }}

--- a/charts/library/ksvc/templates/classes/_cnpg-objectstore.tpl
+++ b/charts/library/ksvc/templates/classes/_cnpg-objectstore.tpl
@@ -1,10 +1,9 @@
 {{- define "ksvc.class.cnpgObjectStore" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
 {{- $store := .Values.postgres.backup.objectStore -}}
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
-  name: {{ $fullname }}-postgres-backup-store
+  name: {{ include "ksvc.postgresBackupStoreName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}

--- a/charts/library/ksvc/templates/classes/_cnpg-podmonitor.tpl
+++ b/charts/library/ksvc/templates/classes/_cnpg-podmonitor.tpl
@@ -1,18 +1,18 @@
 {{- define "ksvc.class.cnpgPodMonitor" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
+{{- $pgName := include "ksvc.postgresName" . -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ $fullname }}-postgres-metrics
+  name: {{ $pgName }}-metrics
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}
-    app: {{ $fullname }}-postgres
+    app: {{ $pgName }}
     release: prometheus
 spec:
   selector:
     matchLabels:
-      postgresql: {{ $fullname }}-postgres
+      postgresql: {{ $pgName }}
   podMetricsEndpoints:
     - port: metrics
       interval: 30s

--- a/charts/library/ksvc/templates/classes/_cnpg-pooler.tpl
+++ b/charts/library/ksvc/templates/classes/_cnpg-pooler.tpl
@@ -1,17 +1,17 @@
 {{- define "ksvc.class.cnpgPooler" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
+{{- $pgName := include "ksvc.postgresName" . -}}
 {{- $pooler := .Values.postgres.pooler -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Pooler
 metadata:
-  name: {{ $fullname }}-postgres-pooler
+  name: {{ $pgName }}-pooler
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}
     app.kubernetes.io/component: database
 spec:
   cluster:
-    name: {{ $fullname }}-postgres
+    name: {{ $pgName }}
   instances: {{ $pooler.instances }}
   type: {{ $pooler.type }}
   pgbouncer:

--- a/charts/library/ksvc/templates/classes/_dragonfly.tpl
+++ b/charts/library/ksvc/templates/classes/_dragonfly.tpl
@@ -37,7 +37,10 @@ spec:
       key: {{ $df.authentication.clientCaCertSecret.key | default "ca.crt" }}
     {{- end }}
   {{- end }}
-  {{- if and $df.tls $df.tls.secretName }}
+  {{- if and $df.tls $df.tls.certManager $df.tls.certManager.enabled }}
+  tlsSecretRef:
+    name: {{ $fullname }}-dragonfly-server-tls
+  {{- else if and $df.tls $df.tls.secretName }}
   tlsSecretRef:
     name: {{ $df.tls.secretName }}
   {{- end }}

--- a/charts/library/ksvc/templates/classes/_dragonfly.tpl
+++ b/charts/library/ksvc/templates/classes/_dragonfly.tpl
@@ -1,10 +1,10 @@
 {{- define "ksvc.class.dragonfly" -}}
-{{- $fullname := include "ksvc.fullname" . -}}
 {{- $df := .Values.dragonfly -}}
+{{- $dfName := include "ksvc.dragonflyName" . -}}
 apiVersion: dragonflydb.io/v1alpha1
 kind: Dragonfly
 metadata:
-  name: {{ $fullname }}-dragonfly
+  name: {{ $dfName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ksvc.labels" . | nindent 4 }}
@@ -39,7 +39,7 @@ spec:
   {{- end }}
   {{- if and $df.tls $df.tls.certManager $df.tls.certManager.enabled }}
   tlsSecretRef:
-    name: {{ $fullname }}-dragonfly-server-tls
+    name: {{ include "ksvc.dragonflyServerTLSSecret" . }}
   {{- else if and $df.tls $df.tls.secretName }}
   tlsSecretRef:
     name: {{ $df.tls.secretName }}

--- a/charts/library/ksvc/templates/classes/_kafka-dlq.tpl
+++ b/charts/library/ksvc/templates/classes/_kafka-dlq.tpl
@@ -4,9 +4,8 @@ Expects context: dict with "root" (top-level context), "key" (source map key),
 and "source" (the merged kafka source config dict containing dlq sub-config).
 */}}
 {{- define "ksvc.class.kafkaDlq" -}}
-{{- $fullname := include "ksvc.fullname" .root -}}
 {{- $dlq := .source.dlq -}}
-{{- $dlqName := printf "%s-%s-dlq" $fullname .key | trunc 63 | trimSuffix "-" -}}
+{{- $dlqName := include "ksvc.kafkaDlqName" . -}}
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:

--- a/charts/library/ksvc/templates/classes/_kafka-source.tpl
+++ b/charts/library/ksvc/templates/classes/_kafka-source.tpl
@@ -5,11 +5,10 @@ and "source" (the merged kafka source config dict).
 The source.sink field must reference a valid key in .Values.services.
 */}}
 {{- define "ksvc.class.kafkaSource" -}}
-{{- $fullname := include "ksvc.fullname" .root -}}
 {{- $source := .source -}}
 {{- $sinkServiceName := include "ksvc.serviceName" (dict "root" .root "key" $source.sink) -}}
-{{- $sourceName := printf "%s-%s-kafka-source" $fullname .key | trunc 63 | trimSuffix "-" -}}
-{{- $dlqName := printf "%s-%s-dlq" $fullname .key | trunc 63 | trimSuffix "-" -}}
+{{- $sourceName := include "ksvc.kafkaSourceName" . -}}
+{{- $dlqName := include "ksvc.kafkaDlqName" . -}}
 apiVersion: sources.knative.dev/v1beta1
 kind: KafkaSource
 metadata:
@@ -19,7 +18,7 @@ metadata:
     {{- include "ksvc.labels" .root | nindent 4 }}
     app.kubernetes.io/component: event-source
 spec:
-  consumerGroup: {{ default (printf "%s-%s-consumers" $fullname .key) $source.consumerGroup }}
+  consumerGroup: {{ default (include "ksvc.kafkaConsumerGroup" .) $source.consumerGroup }}
   consumers: {{ $source.consumers }}
   bootstrapServers:
     {{- toYaml $source.bootstrapServers | nindent 4 }}

--- a/charts/library/ksvc/templates/lib/_names.tpl
+++ b/charts/library/ksvc/templates/lib/_names.tpl
@@ -37,3 +37,39 @@ Returns: <fullname>-<key>
 {{- $fullname := include "ksvc.fullname" .root -}}
 {{- printf "%s-%s" $fullname .key | trunc 63 | trimSuffix "-" | replace "_" "-" }}
 {{- end }}
+
+{{- define "ksvc.postgresName" -}}
+{{- printf "%s-postgres" (include "ksvc.fullname" .) }}
+{{- end }}
+
+{{- define "ksvc.dragonflyName" -}}
+{{- printf "%s-dragonfly" (include "ksvc.fullname" .) }}
+{{- end }}
+
+{{- define "ksvc.postgresBackupStoreName" -}}
+{{- printf "%s-postgres-backup-store" (include "ksvc.fullname" .) }}
+{{- end }}
+
+{{- define "ksvc.postgresServerTLSSecret" -}}
+{{- printf "%s-postgres-server-tls" (include "ksvc.fullname" .) }}
+{{- end }}
+
+{{- define "ksvc.postgresClientTLSSecret" -}}
+{{- printf "%s-postgres-client-tls" (include "ksvc.fullname" .) }}
+{{- end }}
+
+{{- define "ksvc.dragonflyServerTLSSecret" -}}
+{{- printf "%s-dragonfly-server-tls" (include "ksvc.fullname" .) }}
+{{- end }}
+
+{{- define "ksvc.kafkaSourceName" -}}
+{{- printf "%s-%s-kafka-source" (include "ksvc.fullname" .root) .key | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "ksvc.kafkaDlqName" -}}
+{{- printf "%s-%s-dlq" (include "ksvc.fullname" .root) .key | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "ksvc.kafkaConsumerGroup" -}}
+{{- printf "%s-%s-consumers" (include "ksvc.fullname" .root) .key }}
+{{- end }}

--- a/charts/library/ksvc/templates/loader/_generate.tpl
+++ b/charts/library/ksvc/templates/loader/_generate.tpl
@@ -55,6 +55,10 @@ merged. We must apply defaults explicitly before rendering.
 ---
   {{- include "ksvc.class.cnpgAlerts" . | nindent 0 }}
     {{- end }}
+    {{- if and .Values.postgres.certManager .Values.postgres.certManager.enabled }}
+---
+  {{- include "ksvc.class.certManagerPostgres" . | nindent 0 }}
+    {{- end }}
   {{- end }}
 
   {{/* ============================================================ */}}
@@ -77,6 +81,10 @@ merged. We must apply defaults explicitly before rendering.
   {{- if and .Values.dragonfly .Values.dragonfly.enabled }}
 ---
   {{- include "ksvc.class.dragonfly" . | nindent 0 }}
+    {{- if and .Values.dragonfly.tls .Values.dragonfly.tls.certManager .Values.dragonfly.tls.certManager.enabled }}
+---
+  {{- include "ksvc.class.certManagerDragonfly" . | nindent 0 }}
+    {{- end }}
   {{- end }}
 
 {{- end }}
@@ -180,6 +188,7 @@ Uses mustMergeOverwrite: consumer values take precedence over defaults.
       )
     )
     "monitoring" (dict "enabled" true "alerts" (dict "replicationLagWarning" 10 "replicationLagCritical" 60 "highConnectionCount" 50))
+    "certManager" (dict "enabled" false "issuerRef" (dict "name" "" "kind" "" "group" ""))
   -}}
   {{- $pg := .Values.postgres | default dict -}}
   {{- $_ := set .Values "postgres" (mustMergeOverwrite $pgDefaults $pg) -}}
@@ -194,7 +203,7 @@ Uses mustMergeOverwrite: consumer values take precedence over defaults.
     "env" (list)
     "resources" (dict "requests" (dict "cpu" "500m" "memory" "512Mi") "limits" (dict "cpu" "1" "memory" "1Gi"))
     "authentication" (dict "passwordFromSecret" (dict "name" "" "key" "password") "clientCaCertSecret" (dict "name" "" "key" "ca.crt"))
-    "tls" (dict "secretName" "")
+    "tls" (dict "secretName" "" "certManager" (dict "enabled" false "issuerRef" (dict "name" "" "kind" "" "group" "") "duration" "2160h" "renewBefore" "360h"))
     "snapshot" (dict "enabled" false "cron" "0 */6 * * *" "enableOnMasterOnly" true
       "storage" (dict "size" "10Gi" "storageClassName" "")
     )
@@ -213,7 +222,13 @@ Uses mustMergeOverwrite: consumer values take precedence over defaults.
   {{- $_ := set .Values "dragonfly" (mustMergeOverwrite $dfDefaults $df) -}}
 
   {{/* --- global defaults --- */}}
-  {{- $globalDefaults := dict "nameOverride" "" "fullnameOverride" "" "labels" (dict) "annotations" (dict) -}}
+  {{- $globalDefaults := dict
+    "nameOverride" ""
+    "fullnameOverride" ""
+    "labels" (dict)
+    "annotations" (dict)
+    "certManager" (dict "issuerRef" (dict "name" "" "kind" "ClusterIssuer" "group" "cert-manager.io"))
+  -}}
   {{- $global := .Values.global | default dict -}}
   {{- $_ := set .Values "global" (mustMergeOverwrite $globalDefaults $global) -}}
 

--- a/charts/library/ksvc/test-chart/tests/cert-manager-dragonfly_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/cert-manager-dragonfly_test.yaml
@@ -1,0 +1,113 @@
+suite: cert-manager dragonfly tests
+templates:
+  - templates/common.yaml
+set:
+  services.api.image.repository: test/image
+  dragonfly.enabled: true
+  dragonfly.tls.certManager.enabled: true
+  global.certManager.issuerRef.name: my-cluster-issuer
+  global.certManager.issuerRef.kind: ClusterIssuer
+  global.certManager.issuerRef.group: cert-manager.io
+release:
+  name: test-release
+  namespace: test-ns
+tests:
+  - it: should auto-wire tlsSecretRef from cert-manager
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Dragonfly
+      - equal:
+          path: spec.tlsSecretRef.name
+          value: test-release-dragonfly-server-tls
+
+  - it: should render TLS placeholder Secret
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-release-dragonfly-server-tls
+
+  - it: should render Certificate resource
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: metadata.name
+          value: test-release-dragonfly-server-cert
+      - equal:
+          path: spec.secretName
+          value: test-release-dragonfly-server-tls
+      - equal:
+          path: spec.duration
+          value: "2160h"
+      - equal:
+          path: spec.renewBefore
+          value: "360h"
+      - contains:
+          path: spec.usages
+          content: server auth
+      - contains:
+          path: spec.dnsNames
+          content: test-release-dragonfly
+      - contains:
+          path: spec.dnsNames
+          content: test-release-dragonfly.test-ns.svc
+      - contains:
+          path: spec.dnsNames
+          content: test-release-dragonfly.test-ns.svc.cluster.local
+      - equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      - equal:
+          path: spec.issuerRef.group
+          value: cert-manager.io
+
+  - it: should use per-resource issuerRef when set
+    set:
+      dragonfly.tls.certManager.issuerRef.name: dragonfly-issuer
+      dragonfly.tls.certManager.issuerRef.kind: Issuer
+      dragonfly.tls.certManager.issuerRef.group: cert-manager.io
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: dragonfly-issuer
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+
+  - it: should prefer cert-manager over manual secretName
+    set:
+      dragonfly.tls.secretName: manual-secret
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.tlsSecretRef.name
+          value: test-release-dragonfly-server-tls
+
+  - it: should not render cert-manager resources when disabled
+    set:
+      dragonfly.tls.certManager.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should use manual secretName when cert-manager disabled
+    set:
+      dragonfly.tls.certManager.enabled: false
+      dragonfly.tls.secretName: manual-secret
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.tlsSecretRef.name
+          value: manual-secret

--- a/charts/library/ksvc/test-chart/tests/cert-manager-postgres_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/cert-manager-postgres_test.yaml
@@ -1,0 +1,147 @@
+suite: cert-manager postgres tests
+templates:
+  - templates/common.yaml
+set:
+  services.api.image.repository: test/image
+  postgres.enabled: true
+  postgres.pooler.enabled: false
+  postgres.backup.enabled: false
+  postgres.monitoring.enabled: false
+  postgres.certManager.enabled: true
+  global.certManager.issuerRef.name: my-cluster-issuer
+  global.certManager.issuerRef.kind: ClusterIssuer
+  global.certManager.issuerRef.group: cert-manager.io
+release:
+  name: test-release
+  namespace: test-ns
+tests:
+  - it: should add certificates section to CNPG Cluster when certManager enabled
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Cluster
+      - equal:
+          path: spec.certificates.serverTLSSecret
+          value: test-release-postgres-server-tls
+      - equal:
+          path: spec.certificates.serverCASecret
+          value: test-release-postgres-server-tls
+      - equal:
+          path: spec.certificates.clientCASecret
+          value: test-release-postgres-client-tls
+      - equal:
+          path: spec.certificates.replicationTLSSecret
+          value: test-release-postgres-client-tls
+
+  - it: should render server TLS placeholder Secret
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-release-postgres-server-tls
+      - isNotNull:
+          path: metadata.labels["cnpg.io/reload"]
+
+  - it: should render server Certificate resource
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: metadata.name
+          value: test-release-postgres-server-cert
+      - equal:
+          path: spec.secretName
+          value: test-release-postgres-server-tls
+      - contains:
+          path: spec.usages
+          content: server auth
+      - contains:
+          path: spec.dnsNames
+          content: test-release-postgres-rw
+      - contains:
+          path: spec.dnsNames
+          content: test-release-postgres-rw.test-ns.svc
+      - contains:
+          path: spec.dnsNames
+          content: test-release-postgres-r
+      - contains:
+          path: spec.dnsNames
+          content: test-release-postgres-ro
+      - equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+
+  - it: should render client TLS placeholder Secret
+    documentIndex: 4
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-release-postgres-client-tls
+      - isNotNull:
+          path: metadata.labels["cnpg.io/reload"]
+
+  - it: should render client Certificate resource
+    documentIndex: 5
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: metadata.name
+          value: test-release-postgres-client-cert
+      - equal:
+          path: spec.secretName
+          value: test-release-postgres-client-tls
+      - contains:
+          path: spec.usages
+          content: client auth
+      - equal:
+          path: spec.commonName
+          value: streaming_replica
+      - equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+
+  - it: should use per-resource issuerRef when set
+    set:
+      postgres.certManager.issuerRef.name: pg-issuer
+      postgres.certManager.issuerRef.kind: Issuer
+      postgres.certManager.issuerRef.group: cert-manager.io
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: pg-issuer
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+
+  - it: should not render certificates when certManager disabled
+    set:
+      postgres.certManager.enabled: false
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Cluster
+      - isNull:
+          path: spec.certificates
+
+  - it: should not render cert-manager resources when certManager disabled
+    set:
+      postgres.certManager.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/library/ksvc/values.schema.json
+++ b/charts/library/ksvc/values.schema.json
@@ -12,7 +12,14 @@
         "nameOverride": { "type": "string" },
         "fullnameOverride": { "type": "string" },
         "labels": { "type": "object" },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "certManager": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "issuerRef": { "$ref": "#/$defs/issuerRef" }
+          }
+        }
       }
     },
     "services": {
@@ -156,6 +163,14 @@
               }
             }
           }
+        },
+        "certManager": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "issuerRef": { "$ref": "#/$defs/issuerRef" }
+          }
         }
       }
     },
@@ -203,7 +218,17 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "secretName": { "type": "string" }
+            "secretName": { "type": "string" },
+            "certManager": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "issuerRef": { "$ref": "#/$defs/issuerRef" },
+                "duration": { "type": "string" },
+                "renewBefore": { "type": "string" }
+              }
+            }
           }
         },
         "snapshot": {
@@ -498,6 +523,18 @@
         "periodSeconds": { "type": "integer", "minimum": 1 },
         "timeoutSeconds": { "type": "integer", "minimum": 1 },
         "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "issuerRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "kind": {
+          "type": "string",
+          "enum": ["Issuer", "ClusterIssuer", ""]
+        },
+        "group": { "type": "string" }
       }
     }
   }

--- a/charts/library/ksvc/values.yaml
+++ b/charts/library/ksvc/values.yaml
@@ -12,6 +12,15 @@ global:
   # Annotations applied to ALL resources
   annotations: {}
 
+  # Default cert-manager issuer for all Certificate resources.
+  # Individual components (postgres.certManager, dragonfly.tls.certManager) can
+  # override this with their own issuerRef.
+  certManager:
+    issuerRef:
+      name: ""
+      kind: ClusterIssuer
+      group: cert-manager.io
+
 # =============================================================================
 # Services — Map of Knative Services (one or more)
 #
@@ -227,6 +236,17 @@ postgres:
       replicationLagCritical: 60
       highConnectionCount: 50
 
+  # cert-manager integration — generates server + client TLS certificates
+  # via CNPG's native spec.certificates support.
+  # Requires cert-manager CRDs and an Issuer/ClusterIssuer in the cluster.
+  certManager:
+    enabled: false
+    # Override global.certManager.issuerRef for postgres certificates
+    issuerRef:
+      name: ""
+      kind: ""
+      group: ""
+
 # =============================================================================
 # Kafka Event Sources — Map of KafkaSource entries
 #
@@ -286,6 +306,18 @@ dragonfly:
   # TLS — reference a Secret containing tls.crt / tls.key
   tls:
     secretName: ""
+    # cert-manager integration — generates a Certificate resource whose
+    # secret is automatically wired into tlsSecretRef.
+    # When enabled, tls.secretName is ignored (auto-generated name is used).
+    certManager:
+      enabled: false
+      # Override global.certManager.issuerRef for the dragonfly certificate
+      issuerRef:
+        name: ""
+        kind: ""
+        group: ""
+      duration: "2160h"
+      renewBefore: "360h"
 
   # Snapshot / persistence configuration
   snapshot:

--- a/examples/dragonfly-cache/values.yaml
+++ b/examples/dragonfly-cache/values.yaml
@@ -41,6 +41,15 @@ dragonfly:
       key: password
   tls:
     secretName: cache-service-dragonfly-tls
+    ## -- Uncomment to use cert-manager instead of a manually provisioned secret
+    # certManager:
+    #   enabled: true
+    #   issuerRef:                            # optional: overrides global.certManager.issuerRef
+    #     name: my-cluster-issuer
+    #     kind: ClusterIssuer
+    #     group: cert-manager.io
+    #   duration: 2160h
+    #   renewBefore: 360h
   snapshot:
     enabled: true
     cron: "0 */4 * * *"

--- a/examples/full-stack/values.yaml
+++ b/examples/full-stack/values.yaml
@@ -57,6 +57,9 @@ postgres:
   storage:
     size: "200Gi"
     storageClassName: "gp3"
+  ## -- Uncomment to let cert-manager generate server & client TLS certificates
+  # certManager:
+  #   enabled: true
   pooler:
     enabled: true
     instances: 3
@@ -115,6 +118,10 @@ dragonfly:
     passwordFromSecret:
       name: full-stack-service-dragonfly-auth
       key: password
+  ## -- Uncomment to let cert-manager generate TLS certificates for Dragonfly
+  # tls:
+  #   certManager:
+  #     enabled: true
   snapshot:
     enabled: true
     cron: "0 */6 * * *"

--- a/examples/postgres-only/values.yaml
+++ b/examples/postgres-only/values.yaml
@@ -29,6 +29,13 @@ postgres:
   storage:
     size: "100Gi"
     storageClassName: "standard"
+  ## -- Uncomment to let cert-manager generate server & client TLS certificates
+  # certManager:
+  #   enabled: true
+  #   issuerRef:                            # optional: overrides global.certManager.issuerRef
+  #     name: my-cluster-issuer
+  #     kind: ClusterIssuer
+  #     group: cert-manager.io
   backup:
     enabled: true
     schedule: "0 3 * * *"


### PR DESCRIPTION
## Summary

- Add retry logic (3 attempts with 5s backoff) to all CRD install steps in the integration test workflow, preventing transient network/API server timing failures
- Create `test-ns` namespace before the "Verify rendered resources via kubectl" step, fixing the `namespaces "test-ns" not found` error when `kubectl apply --dry-run=server` runs against resources that reference that namespace
- Apply the same retry logic to the app-chart job's Knative CRD install step

Fixes the intermittent `Kind Cluster Deploy (minimal)` CI failure.