### PR TITLE
feat(ksvc): add per-service nameOverride for kustomize-compatible naming

### DIFF
--- a/charts/library/ksvc/README.md
+++ b/charts/library/ksvc/README.md
@@ -30,12 +30,14 @@ Consumer Chart
 
 | Resource | Name Pattern |
 |----------|-------------|
-| Knative Service | `<release>-<service-key>` |
-| Flagger Canary | `<release>-<service-key>` |
+| Knative Service | `<release>-<service-key>` (or `<release>-<nameOverride>` when set) |
+| Flagger Canary | `<release>-<service-key>` (or `<release>-<nameOverride>` when set) |
 | KafkaSource | `<release>-<source-key>-kafka-source` |
 | DLQ Service | `<release>-<source-key>-dlq` |
 | CNPG Cluster | `<release>` (global) |
 | Dragonfly | `<release>` (global) |
+
+Use `nameOverride: ""` on a service entry to produce just `<release>` with no suffix — useful for single-service deployments or kustomize compatibility.
 
 ## Quick Start
 
@@ -97,10 +99,11 @@ Consumer Chart
 
 ### Services (Map)
 
-Each key in `services:` defines a Knative Service. The key becomes a name suffix: `<release>-<key>`.
+Each key in `services:` defines a Knative Service. The key becomes a name suffix: `<release>-<key>`. Set `nameOverride` to change the suffix or use `""` for no suffix.
 
 | Key | Description | Default |
 |-----|-------------|---------|
+| `services.<key>.nameOverride` | Override the name suffix (replaces the map key). Set to `""` for no suffix. | *(not set — uses key)* |
 | `services.<key>.image.repository` | Container image repository | `""` |
 | `services.<key>.image.tag` | Container image tag | `"latest"` |
 | `services.<key>.image.pullPolicy` | Image pull policy | `IfNotPresent` |

--- a/charts/library/ksvc/templates/classes/_flagger-canary.tpl
+++ b/charts/library/ksvc/templates/classes/_flagger-canary.tpl
@@ -4,7 +4,7 @@ Expects context: dict with "root" (top-level context), "key" (service map key),
 and "svc" (the merged service config dict containing flagger sub-config).
 */}}
 {{- define "ksvc.class.flaggerCanary" -}}
-{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key) -}}
+{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key "svc" .svc) -}}
 {{- $flagger := .svc.flagger -}}
 {{- $lt := $flagger.loadTest -}}
 apiVersion: flagger.app/v1beta1

--- a/charts/library/ksvc/templates/classes/_knative-service.tpl
+++ b/charts/library/ksvc/templates/classes/_knative-service.tpl
@@ -4,7 +4,7 @@ Expects context: dict with "root" (top-level context), "key" (service map key),
 and "svc" (the merged service config dict).
 */}}
 {{- define "ksvc.class.knativeService" -}}
-{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key) -}}
+{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key "svc" .svc) -}}
 {{- $svc := .svc -}}
 apiVersion: serving.knative.dev/v1
 kind: Service

--- a/charts/library/ksvc/templates/lib/_labels.tpl
+++ b/charts/library/ksvc/templates/lib/_labels.tpl
@@ -26,7 +26,7 @@ Expects context: dict with "root" (top-level context), "key" (service map key),
 and "svc" (the service config dict).
 */}}
 {{- define "ksvc.serviceLabels" -}}
-{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key) -}}
+{{- $serviceName := include "ksvc.serviceName" (dict "root" .root "key" .key "svc" .svc) -}}
 app.kubernetes.io/name: {{ $serviceName }}
 app.kubernetes.io/instance: {{ .root.Release.Name }}
 app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}

--- a/charts/library/ksvc/templates/lib/_names.tpl
+++ b/charts/library/ksvc/templates/lib/_names.tpl
@@ -30,12 +30,20 @@ Chart label value.
 
 {{/*
 ksvc.serviceName — Derive resource name for a service entry.
-Expects context: dict with "root" (top-level context) and "key" (service map key).
-Returns: <fullname>-<key>
+Expects context: dict with "root" (top-level context), "key" (service map key),
+and "svc" (the service config dict).
+When svc.nameOverride is set, it replaces the key as the name suffix.
+An empty nameOverride produces just <fullname> (no suffix), which is useful
+for single-service deployments that want a clean resource name.
+Returns: <fullname>-<suffix>  (or just <fullname> when suffix is empty)
 */}}
 {{- define "ksvc.serviceName" -}}
 {{- $fullname := include "ksvc.fullname" .root -}}
-{{- printf "%s-%s" $fullname .key | trunc 63 | trimSuffix "-" | replace "_" "-" }}
+{{- $suffix := .key -}}
+{{- if and .svc (hasKey .svc "nameOverride") -}}
+  {{- $suffix = .svc.nameOverride -}}
+{{- end -}}
+{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" | replace "_" "-" }}
 {{- end }}
 
 {{- define "ksvc.postgresName" -}}

--- a/charts/library/ksvc/test-chart/Chart.lock
+++ b/charts/library/ksvc/test-chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ksvc
   repository: file://..
-  version: 0.6.0
-digest: sha256:d0357e65b09b7d7cb89787ccd03a2415e7bad2d405be18b1ac210be9ff2d0a55
-generated: "2026-04-09T03:45:30.040576061Z"
+  version: 0.6.3
+digest: sha256:d238786f0c43d91f93979900826211e994573534e15af07ae274d41661cc3dc2
+generated: "2026-04-11T02:53:17.897081809Z"

--- a/charts/library/ksvc/test-chart/tests/flagger-canary_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/flagger-canary_test.yaml
@@ -81,3 +81,15 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+
+  - it: should use nameOverride in canary and targetRef names
+    set:
+      services.api.nameOverride: ""
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release
+      - equal:
+          path: spec.targetRef.name
+          value: test-release

--- a/charts/library/ksvc/test-chart/tests/knative-service_test.yaml
+++ b/charts/library/ksvc/test-chart/tests/knative-service_test.yaml
@@ -131,3 +131,30 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
+
+  - it: should use nameOverride as name suffix when set
+    set:
+      services.api.nameOverride: web
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-web
+
+  - it: should produce release name only when nameOverride is empty string
+    set:
+      services.api.nameOverride: ""
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release
+
+  - it: should keep component label as the map key even with nameOverride
+    set:
+      services.api.nameOverride: ""
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: api

--- a/charts/library/ksvc/values.schema.json
+++ b/charts/library/ksvc/values.schema.json
@@ -315,6 +315,10 @@
       "additionalProperties": false,
       "required": ["image"],
       "properties": {
+        "nameOverride": {
+          "type": "string",
+          "description": "Override the name suffix for this service. When set, replaces the map key in the resource name: <release>-<nameOverride>. Set to empty string to produce just <release> with no suffix."
+        },
         "image": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/library/ksvc/values.yaml
+++ b/charts/library/ksvc/values.yaml
@@ -25,12 +25,16 @@ global:
 # Services — Map of Knative Services (one or more)
 #
 # Each key becomes a name suffix: <release-name>-<key>
+# Use nameOverride to change the suffix (or set to "" for no suffix).
 # Example:
 #   services:
 #     api:
 #       image: { repository: ghcr.io/org/api, tag: v1.0.0 }
 #     worker:
 #       image: { repository: ghcr.io/org/worker, tag: v1.0.0 }
+#     app:
+#       nameOverride: ""    # produces just <release-name> with no suffix
+#       image: { repository: ghcr.io/org/app, tag: v1.0.0 }
 # =============================================================================
 services:
   api:


### PR DESCRIPTION
## Summary

- Add `nameOverride` field to service entries in the ksvc library chart, allowing consumers to use real YAML map keys while controlling the final Kubernetes resource name
- Fixes kustomize strategic merge patch failures caused by empty-string map keys (`""`) that kustomize cannot parse (`ScalarNode vs MappingNode` error)

## Problem

Consumers using a single service needed `services: "": { ... }` to produce a clean resource name (`<release>` with no suffix). This empty-string key breaks `kubectl apply -k` / kustomize because kustomize's strategic merge patch parser cannot handle empty-string YAML map keys.

## Solution

The `ksvc.serviceName` template now accepts an optional `nameOverride` in the service config:

```yaml
# Before (breaks kustomize)
services:
  "":
    image: ...

# After (kustomize-compatible)
services:
  app:
    nameOverride: ""    # produces just <release> with no suffix
    image: ...
```

When `nameOverride` is present (via `hasKey`), it replaces the map key as the name suffix. When absent, behavior is unchanged — the map key is used as before.

## Changes

| File | Change |
|------|--------|
| `_names.tpl` | `ksvc.serviceName` checks `svc.nameOverride` via `hasKey`, falls back to `.key` |
| `_labels.tpl` | Pass `.svc` to `ksvc.serviceName`; component label stays as `.key` |
| `_knative-service.tpl` | Pass `.svc` in `ksvc.serviceName` call |
| `_flagger-canary.tpl` | Pass `.svc` in `ksvc.serviceName` call |
| `values.schema.json` | Add `nameOverride` (string) to `serviceEntry` |
| `values.yaml` | Document `nameOverride` usage in comments |
| `README.md` | Update naming conventions and values reference |
| `knative-service_test.yaml` | 3 new tests: custom suffix, empty string, component label preservation |
| `flagger-canary_test.yaml` | 1 new test: nameOverride flows through to canary name + targetRef |

## Testing

All 79 helm-unittest tests pass (75 existing + 4 new).